### PR TITLE
feat: harden attachments and add upload-url v2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+package-import-method=copy
+verify-store-integrity=false
+strict-peer-dependencies=false

--- a/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
@@ -48,6 +48,7 @@ using EduConnect.Api.Features.Notifications.GetUnreadCount;
 using EduConnect.Api.Features.Notifications.MarkNotificationRead;
 using EduConnect.Api.Features.Notifications.MarkAllNotificationsRead;
 using EduConnect.Api.Features.Attachments.RequestUploadUrl;
+using EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
 using EduConnect.Api.Features.Attachments.AttachFileToEntity;
 using EduConnect.Api.Features.Attachments.DeleteAttachment;
 using EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
@@ -185,6 +186,7 @@ public static class EndpointRouteBuilderExtensions
         var group = app.MapGroup("/api/attachments").WithTags("Attachments").RequireAuthorization();
 
         group.MapPost("/request-upload-url", RequestUploadUrlEndpoint.Handle).WithName("RequestUploadUrl");
+        group.MapPost("/request-upload-url-v2", RequestUploadUrlV2Endpoint.Handle).WithName("RequestUploadUrlV2");
         group.MapPost("/attach", AttachFileToEntityEndpoint.Handle).WithName("AttachFileToEntity");
         group.MapGet("/", GetAttachmentsForEntityEndpoint.Handle).WithName("GetAttachmentsForEntity");
         group.MapDelete("/{id}", DeleteAttachmentEndpoint.Handle).WithName("DeleteAttachment");

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
@@ -1,4 +1,5 @@
 using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Features.Attachments;
 using EduConnect.Api.Common.Exceptions;
 using EduConnect.Api.Infrastructure.Database;
 using MediatR;
@@ -10,8 +11,6 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
     private readonly AppDbContext _context;
     private readonly CurrentUserService _currentUserService;
     private readonly ILogger<AttachFileToEntityCommandHandler> _logger;
-
-    private const int MaxAttachmentsPerEntity = 5;
 
     public AttachFileToEntityCommandHandler(
         AppDbContext context,
@@ -48,6 +47,12 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
             throw new InvalidOperationException("This attachment is already associated with an entity.");
         }
 
+        if (!string.IsNullOrWhiteSpace(attachment.EntityType) &&
+            !string.Equals(attachment.EntityType, request.EntityType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("This attachment was prepared for a different entity type.");
+        }
+
         // Verify the target entity exists in the correct table
         if (request.EntityType == "homework")
         {
@@ -57,6 +62,19 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
             if (homework == null)
             {
                 throw new NotFoundException("Homework", request.EntityId.ToString());
+            }
+
+            if (_currentUserService.Role == "Teacher")
+            {
+                if (homework.AssignedById != _currentUserService.UserId)
+                {
+                    throw new ForbiddenException("You can only attach files to homework you created.");
+                }
+
+                if (homework.Status != "Draft" && homework.Status != "Rejected")
+                {
+                    throw new ForbiddenException("Attachments can only be changed while homework is editable.");
+                }
             }
         }
         else if (request.EntityType == "notice")
@@ -68,6 +86,11 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
             {
                 throw new NotFoundException("Notice", request.EntityId.ToString());
             }
+
+            if (notice.IsPublished)
+            {
+                throw new ForbiddenException("Attachments can only be changed before the notice is published.");
+            }
         }
 
         // Check max 5 attachments per entity
@@ -78,9 +101,9 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
                 a.SchoolId == _currentUserService.SchoolId,
                 cancellationToken);
 
-        if (existingCount >= MaxAttachmentsPerEntity)
+        if (existingCount >= AttachmentFeatureRules.MaxAttachmentsPerEntity)
         {
-            throw new InvalidOperationException($"Maximum of {MaxAttachmentsPerEntity} attachments per entity reached.");
+            throw new InvalidOperationException($"Maximum of {AttachmentFeatureRules.MaxAttachmentsPerEntity} attachments per entity reached.");
         }
 
         // Associate the attachment

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachmentRules.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachmentRules.cs
@@ -1,0 +1,63 @@
+namespace EduConnect.Api.Features.Attachments;
+
+public static class AttachmentFeatureRules
+{
+    public const int MaxAttachmentsPerEntity = 5;
+
+    public static readonly string[] SupportedEntityTypes =
+    [
+        "homework",
+        "notice"
+    ];
+
+    public static readonly string[] HomeworkAllowedContentTypes =
+    [
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ];
+
+    public static readonly string[] HomeworkAllowedExtensions =
+    [
+        ".pdf",
+        ".doc",
+        ".docx"
+    ];
+
+    public static readonly string[] NoticeAllowedContentTypes =
+    [
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "application/pdf"
+    ];
+
+    public static readonly string[] NoticeAllowedExtensions =
+    [
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".webp",
+        ".pdf"
+    ];
+
+    public static IReadOnlyList<string> GetAllowedContentTypes(string entityType) =>
+        entityType switch
+        {
+            "homework" => HomeworkAllowedContentTypes,
+            "notice" => NoticeAllowedContentTypes,
+            _ => Array.Empty<string>()
+        };
+
+    public static IReadOnlyList<string> GetAllowedExtensions(string entityType) =>
+        entityType switch
+        {
+            "homework" => HomeworkAllowedExtensions,
+            "notice" => NoticeAllowedExtensions,
+            _ => Array.Empty<string>()
+        };
+
+    public static bool RequiresForcedDownload(string contentType) =>
+        contentType == "application/msword" ||
+        contentType == "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+}

--- a/apps/api/src/EduConnect.Api/Features/Attachments/DeleteAttachment/DeleteAttachmentCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/DeleteAttachment/DeleteAttachmentCommandHandler.cs
@@ -43,17 +43,51 @@ public class DeleteAttachmentCommandHandler : IRequestHandler<DeleteAttachmentCo
             throw new NotFoundException("Attachment", request.AttachmentId.ToString());
         }
 
-        // Teachers can only delete their own attachments; admins can delete any
-        if (_currentUserService.Role == "Teacher" && attachment.UploadedById != _currentUserService.UserId)
+        if (attachment.EntityType == "homework" && attachment.EntityId.HasValue)
         {
-            throw new ForbiddenException("You can only delete your own attachments.");
+            var homework = await _context.Homeworks
+                .FirstOrDefaultAsync(
+                    h => h.Id == attachment.EntityId &&
+                         h.SchoolId == _currentUserService.SchoolId &&
+                         !h.IsDeleted,
+                    cancellationToken);
+
+            if (homework == null)
+            {
+                throw new NotFoundException("Homework", attachment.EntityId.Value.ToString());
+            }
+
+            if (_currentUserService.Role == "Teacher")
+            {
+                if (homework.AssignedById != _currentUserService.UserId)
+                {
+                    throw new ForbiddenException("You can only delete attachments from homework you created.");
+                }
+
+                if (homework.Status != "Draft" && homework.Status != "Rejected")
+                {
+                    throw new ForbiddenException("Attachments can only be deleted while homework is editable.");
+                }
+            }
+        }
+        else
+        {
+            // Teachers can only delete their own attachments; admins can delete any.
+            if (_currentUserService.Role == "Teacher" && attachment.UploadedById != _currentUserService.UserId)
+            {
+                throw new ForbiddenException("You can only delete your own attachments.");
+            }
         }
 
-        // If attached to a published notice, block deletion
         if (attachment.EntityType == "notice" && attachment.EntityId.HasValue)
         {
             var notice = await _context.Notices
-                .FirstOrDefaultAsync(n => n.Id == attachment.EntityId && n.IsPublished, cancellationToken);
+                .FirstOrDefaultAsync(
+                    n => n.Id == attachment.EntityId &&
+                         n.SchoolId == _currentUserService.SchoolId &&
+                         !n.IsDeleted &&
+                         n.IsPublished,
+                    cancellationToken);
 
             if (notice != null)
             {

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
@@ -1,5 +1,8 @@
 using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Features.Attachments;
 using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
 using EduConnect.Api.Infrastructure.Services;
 using MediatR;
 
@@ -23,6 +26,15 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
 
     public async Task<List<AttachmentDto>> Handle(GetAttachmentsForEntityQuery request, CancellationToken cancellationToken)
     {
+        if (request.EntityType == "homework")
+        {
+            await EnsureHomeworkAccessAsync(request.EntityId, cancellationToken);
+        }
+        else if (request.EntityType == "notice")
+        {
+            await EnsureNoticeAccessAsync(request.EntityId, cancellationToken);
+        }
+
         var attachments = await _context.Attachments
             .Where(a =>
                 a.EntityId == request.EntityId &&
@@ -35,10 +47,12 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
 
         foreach (var attachment in attachments)
         {
-            // Generate 1-hour presigned download URL
             var downloadUrl = await _storageService.GeneratePresignedDownloadUrlAsync(
                 attachment.StorageKey,
                 TimeSpan.FromHours(1),
+                attachment.FileName,
+                attachment.ContentType,
+                AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
                 cancellationToken);
 
             result.Add(new AttachmentDto(
@@ -51,5 +65,137 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
         }
 
         return result;
+    }
+
+    private async Task EnsureHomeworkAccessAsync(Guid homeworkId, CancellationToken cancellationToken)
+    {
+        var homework = await _context.Homeworks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                h => h.Id == homeworkId &&
+                     h.SchoolId == _currentUserService.SchoolId &&
+                     !h.IsDeleted,
+                cancellationToken);
+
+        if (homework == null)
+        {
+            throw new NotFoundException("Homework", homeworkId.ToString());
+        }
+
+        if (_currentUserService.Role == "Admin")
+        {
+            return;
+        }
+
+        if (_currentUserService.Role == "Parent")
+        {
+            var linkedClassIds = await _context.ParentStudentLinks
+                .Where(link =>
+                    link.SchoolId == _currentUserService.SchoolId &&
+                    link.ParentId == _currentUserService.UserId)
+                .Join(_context.Students, link => link.StudentId, student => student.Id, (_, student) => student.ClassId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            if (homework.Status == "Published" && linkedClassIds.Contains(homework.ClassId))
+            {
+                return;
+            }
+
+            throw new ForbiddenException("You do not have access to these homework attachments.");
+        }
+
+        if (_currentUserService.Role == "Teacher")
+        {
+            if (homework.AssignedById == _currentUserService.UserId)
+            {
+                return;
+            }
+
+            var assignedClassIds = await _context.TeacherClassAssignments
+                .Where(assignment =>
+                    assignment.SchoolId == _currentUserService.SchoolId &&
+                    assignment.TeacherId == _currentUserService.UserId)
+                .Select(assignment => assignment.ClassId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            if (homework.Status == "Published" && assignedClassIds.Contains(homework.ClassId))
+            {
+                return;
+            }
+
+            var classTeacherClassIds = await _context.TeacherClassAssignments
+                .Where(assignment =>
+                    assignment.SchoolId == _currentUserService.SchoolId &&
+                    assignment.TeacherId == _currentUserService.UserId &&
+                    assignment.IsClassTeacher)
+                .Select(assignment => assignment.ClassId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            if (homework.Status == "PendingApproval" && classTeacherClassIds.Contains(homework.ClassId))
+            {
+                return;
+            }
+        }
+
+        throw new ForbiddenException("You do not have access to these homework attachments.");
+    }
+
+    private async Task EnsureNoticeAccessAsync(Guid noticeId, CancellationToken cancellationToken)
+    {
+        var notice = await _context.Notices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                n => n.Id == noticeId &&
+                     n.SchoolId == _currentUserService.SchoolId &&
+                     !n.IsDeleted,
+                cancellationToken);
+
+        if (notice == null)
+        {
+            throw new NotFoundException("Notice", noticeId.ToString());
+        }
+
+        if (_currentUserService.Role == "Admin" || _currentUserService.Role == "Teacher")
+        {
+            return;
+        }
+
+        if (_currentUserService.Role != "Parent")
+        {
+            throw new ForbiddenException("You do not have access to these notice attachments.");
+        }
+
+        if (!notice.IsPublished)
+        {
+            throw new ForbiddenException("You do not have access to these notice attachments.");
+        }
+
+        if (notice.ExpiresAt.HasValue && notice.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+        {
+            throw new ForbiddenException("You do not have access to these notice attachments.");
+        }
+
+        if (string.Equals(notice.TargetAudience, "All", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var studentClassIds = await _context.ParentStudentLinks
+            .Where(link =>
+                link.SchoolId == _currentUserService.SchoolId &&
+                link.ParentId == _currentUserService.UserId)
+            .Join(_context.Students, link => link.StudentId, student => student.Id, (_, student) => student.ClassId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (notice.TargetClassId.HasValue && studentClassIds.Contains(notice.TargetClassId.Value))
+        {
+            return;
+        }
+
+        throw new ForbiddenException("You do not have access to these notice attachments.");
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryValidator.cs
@@ -1,0 +1,18 @@
+using EduConnect.Api.Features.Attachments;
+using FluentValidation;
+
+namespace EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
+
+public class GetAttachmentsForEntityQueryValidator : AbstractValidator<GetAttachmentsForEntityQuery>
+{
+    public GetAttachmentsForEntityQueryValidator()
+    {
+        RuleFor(x => x.EntityId)
+            .NotEmpty().WithMessage("Entity ID is required.");
+
+        RuleFor(x => x.EntityType)
+            .NotEmpty().WithMessage("Entity type is required.")
+            .Must(entityType => AttachmentFeatureRules.SupportedEntityTypes.Contains(entityType))
+            .WithMessage("Entity type must be 'homework' or 'notice'.");
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrl/RequestUploadUrlCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrl/RequestUploadUrlCommandValidator.cs
@@ -1,17 +1,13 @@
+using EduConnect.Api.Features.Attachments;
+using EduConnect.Api.Infrastructure.Services;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace EduConnect.Api.Features.Attachments.RequestUploadUrl;
 
 public class RequestUploadUrlCommandValidator : AbstractValidator<RequestUploadUrlCommand>
 {
-    private static readonly string[] AllowedContentTypes =
-    {
-        "image/jpeg", "image/png", "image/webp", "application/pdf"
-    };
-
-    private const int MaxSizeBytes = 10 * 1024 * 1024; // 10MB
-
-    public RequestUploadUrlCommandValidator()
+    public RequestUploadUrlCommandValidator(IOptions<StorageOptions> storageOptions)
     {
         RuleFor(x => x.FileName)
             .NotEmpty().WithMessage("File name is required.")
@@ -19,11 +15,12 @@ public class RequestUploadUrlCommandValidator : AbstractValidator<RequestUploadU
 
         RuleFor(x => x.ContentType)
             .NotEmpty().WithMessage("Content type is required.")
-            .Must(ct => AllowedContentTypes.Contains(ct))
+            .Must(ct => AttachmentFeatureRules.NoticeAllowedContentTypes.Contains(ct))
             .WithMessage("Content type must be one of: image/jpeg, image/png, image/webp, application/pdf.");
 
         RuleFor(x => x.SizeBytes)
             .GreaterThan(0).WithMessage("File size must be greater than zero.")
-            .LessThanOrEqualTo(MaxSizeBytes).WithMessage("File size must not exceed 10MB.");
+            .LessThanOrEqualTo((int)storageOptions.Value.MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {storageOptions.Value.MaxFileSizeBytes / (1024 * 1024)}MB.");
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Command.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Command.cs
@@ -1,0 +1,11 @@
+namespace EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
+
+public record RequestUploadUrlV2Command(
+    string FileName,
+    string ContentType,
+    int SizeBytes,
+    string EntityType) : IRequest<RequestUploadUrlV2Response>;
+
+public record RequestUploadUrlV2Response(
+    string UploadUrl,
+    Guid AttachmentId);

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandHandler.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
+
+public class RequestUploadUrlV2CommandHandler : IRequestHandler<RequestUploadUrlV2Command, RequestUploadUrlV2Response>
+{
+    private readonly AppDbContext _context;
+    private readonly CurrentUserService _currentUserService;
+    private readonly IStorageService _storageService;
+    private readonly StorageOptions _storageOptions;
+    private readonly ILogger<RequestUploadUrlV2CommandHandler> _logger;
+
+    public RequestUploadUrlV2CommandHandler(
+        AppDbContext context,
+        CurrentUserService currentUserService,
+        IStorageService storageService,
+        IOptions<StorageOptions> storageOptions,
+        ILogger<RequestUploadUrlV2CommandHandler> logger)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _storageService = storageService;
+        _storageOptions = storageOptions.Value;
+        _logger = logger;
+    }
+
+    public async Task<RequestUploadUrlV2Response> Handle(RequestUploadUrlV2Command request, CancellationToken cancellationToken)
+    {
+        if (_currentUserService.Role != "Admin" && _currentUserService.Role != "Teacher")
+        {
+            throw new ForbiddenException("Only admins and teachers can upload attachments.");
+        }
+
+        var sanitizedFileName = SanitizeFileName(request.FileName);
+        var extension = Path.GetExtension(sanitizedFileName);
+        var attachmentId = Guid.NewGuid();
+        var storageKey = $"{_currentUserService.SchoolId}/{request.EntityType}/{attachmentId}-{sanitizedFileName}";
+
+        var attachment = new AttachmentEntity
+        {
+            Id = attachmentId,
+            SchoolId = _currentUserService.SchoolId,
+            EntityId = null,
+            EntityType = request.EntityType,
+            StorageKey = storageKey,
+            FileName = sanitizedFileName,
+            ContentType = request.ContentType,
+            SizeBytes = request.SizeBytes,
+            UploadedById = _currentUserService.UserId,
+            UploadedAt = DateTimeOffset.UtcNow
+        };
+
+        _context.Attachments.Add(attachment);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var uploadUrl = await _storageService.GeneratePresignedUploadUrlAsync(
+            storageKey,
+            request.ContentType,
+            TimeSpan.FromMinutes(_storageOptions.PresignedUploadExpiryMinutes),
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Upload URL v2 generated: attachment {AttachmentId} for {EntityType} by user {UserId} with extension {Extension}",
+            attachmentId,
+            request.EntityType,
+            _currentUserService.UserId,
+            extension);
+
+        return new RequestUploadUrlV2Response(uploadUrl, attachmentId);
+    }
+
+    private static string SanitizeFileName(string fileName)
+    {
+        var safeFileName = Path.GetFileName(fileName).Trim();
+        if (string.IsNullOrWhiteSpace(safeFileName))
+        {
+            return "file";
+        }
+
+        var builder = new StringBuilder(safeFileName.Length);
+        foreach (var character in safeFileName)
+        {
+            builder.Append(Path.GetInvalidFileNameChars().Contains(character)
+                ? '-'
+                : character);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandValidator.cs
@@ -1,0 +1,40 @@
+using EduConnect.Api.Features.Attachments;
+using EduConnect.Api.Infrastructure.Services;
+using FluentValidation;
+using Microsoft.Extensions.Options;
+
+namespace EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
+
+public class RequestUploadUrlV2CommandValidator : AbstractValidator<RequestUploadUrlV2Command>
+{
+    public RequestUploadUrlV2CommandValidator(IOptions<StorageOptions> storageOptions)
+    {
+        RuleFor(x => x.FileName)
+            .NotEmpty().WithMessage("File name is required.")
+            .MaximumLength(255).WithMessage("File name must be 255 characters or fewer.");
+
+        RuleFor(x => x.EntityType)
+            .NotEmpty().WithMessage("Entity type is required.")
+            .Must(entityType => AttachmentFeatureRules.SupportedEntityTypes.Contains(entityType))
+            .WithMessage("Entity type must be 'homework' or 'notice'.");
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithMessage("Content type is required.")
+            .Must((command, contentType) =>
+                AttachmentFeatureRules.GetAllowedContentTypes(command.EntityType).Contains(contentType))
+            .WithMessage("This file type is not allowed for the selected entity.");
+
+        RuleFor(x => x.FileName)
+            .Must((command, fileName) =>
+            {
+                var extension = Path.GetExtension(Path.GetFileName(fileName)).ToLowerInvariant();
+                return AttachmentFeatureRules.GetAllowedExtensions(command.EntityType).Contains(extension);
+            })
+            .WithMessage("Invalid file extension for the selected entity.");
+
+        RuleFor(x => x.SizeBytes)
+            .GreaterThan(0).WithMessage("File size must be greater than zero.")
+            .LessThanOrEqualTo((int)storageOptions.Value.MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {storageOptions.Value.MaxFileSizeBytes / (1024 * 1024)}MB.");
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Endpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Endpoint.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
+
+public static class RequestUploadUrlV2Endpoint
+{
+    public static async Task<IResult> Handle(RequestUploadUrlV2Command command, IMediator mediator, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(command, cancellationToken);
+        return Results.Ok(result);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Migrations/schema/013_expand_attachment_content_types_for_word_documents.sql
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Migrations/schema/013_expand_attachment_content_types_for_word_documents.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- Migration 013: Expand attachment content types to support Word documents
+-- Fully idempotent — safe to retry.
+-- ============================================================================
+
+ALTER TABLE attachments
+    DROP CONSTRAINT IF EXISTS chk_attachment_content_type;
+
+ALTER TABLE attachments
+    ADD CONSTRAINT chk_attachment_content_type CHECK (
+        content_type IN (
+            'image/jpeg',
+            'image/png',
+            'image/webp',
+            'application/pdf',
+            'application/msword',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+    );

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
@@ -17,6 +17,9 @@ public interface IStorageService
     Task<string> GeneratePresignedDownloadUrlAsync(
         string key,
         TimeSpan expiresIn,
+        string? fileName = null,
+        string? contentType = null,
+        bool forceDownload = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
@@ -1,18 +1,22 @@
 using Amazon.S3;
 using Amazon.S3.Model;
+using Microsoft.Extensions.Options;
 
 namespace EduConnect.Api.Infrastructure.Services;
 
 public class S3StorageService : IStorageService
 {
     private readonly IAmazonS3 _s3Client;
-    private readonly string _bucketName;
+    private readonly StorageOptions _storageOptions;
     private readonly ILogger<S3StorageService> _logger;
 
-    public S3StorageService(IAmazonS3 s3Client, IConfiguration configuration, ILogger<S3StorageService> logger)
+    public S3StorageService(
+        IAmazonS3 s3Client,
+        IOptions<StorageOptions> storageOptions,
+        ILogger<S3StorageService> logger)
     {
         _s3Client = s3Client;
-        _bucketName = configuration["S3_BUCKET_NAME"] ?? "educonnect-attachments";
+        _storageOptions = storageOptions.Value;
         _logger = logger;
     }
 
@@ -24,7 +28,7 @@ public class S3StorageService : IStorageService
     {
         var request = new GetPreSignedUrlRequest
         {
-            BucketName = _bucketName,
+            BucketName = _storageOptions.BucketName,
             Key = key,
             Verb = HttpVerb.PUT,
             Expires = DateTime.UtcNow.Add(expiresIn),
@@ -41,15 +45,35 @@ public class S3StorageService : IStorageService
     public Task<string> GeneratePresignedDownloadUrlAsync(
         string key,
         TimeSpan expiresIn,
+        string? fileName = null,
+        string? contentType = null,
+        bool forceDownload = false,
         CancellationToken cancellationToken = default)
     {
         var request = new GetPreSignedUrlRequest
         {
-            BucketName = _bucketName,
+            BucketName = _storageOptions.BucketName,
             Key = key,
             Verb = HttpVerb.GET,
             Expires = DateTime.UtcNow.Add(expiresIn)
         };
+
+        if (!string.IsNullOrWhiteSpace(fileName) || !string.IsNullOrWhiteSpace(contentType))
+        {
+            request.ResponseHeaderOverrides = new ResponseHeaderOverrides();
+
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                var dispositionType = forceDownload ? "attachment" : "inline";
+                request.ResponseHeaderOverrides.ContentDisposition =
+                    $"{dispositionType}; filename*=UTF-8''{Uri.EscapeDataString(fileName)}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(contentType))
+            {
+                request.ResponseHeaderOverrides.ContentType = contentType;
+            }
+        }
 
         var url = _s3Client.GetPreSignedURL(request);
 
@@ -60,7 +84,7 @@ public class S3StorageService : IStorageService
     {
         var request = new DeleteObjectRequest
         {
-            BucketName = _bucketName,
+            BucketName = _storageOptions.BucketName,
             Key = key
         };
 

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/StorageOptions.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/StorageOptions.cs
@@ -1,0 +1,13 @@
+namespace EduConnect.Api.Infrastructure.Services;
+
+public class StorageOptions
+{
+    public const string SectionName = "Storage";
+
+    public string BucketName { get; set; } = "educonnect-attachments";
+    public string Region { get; set; } = "ap-south-1";
+    public string? ServiceUrl { get; set; }
+    public int PresignedUploadExpiryMinutes { get; set; } = 15;
+    public int PresignedDownloadExpiryMinutes { get; set; } = 60;
+    public long MaxFileSizeBytes { get; set; } = 10 * 1024 * 1024;
+}

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -10,6 +10,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Options;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -79,6 +80,19 @@ builder.Services.AddScoped<CurrentUserService>();
 builder.Services.AddScoped<IDateTimeProvider, DateTimeProvider>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 
+var storageOptions = builder.Configuration.GetSection(StorageOptions.SectionName).Get<StorageOptions>() ?? new StorageOptions();
+storageOptions.BucketName =
+    builder.Configuration["S3_BUCKET_NAME"] ??
+    storageOptions.BucketName;
+storageOptions.Region =
+    builder.Configuration["AWS_REGION"] ??
+    storageOptions.Region;
+storageOptions.ServiceUrl =
+    builder.Configuration["S3_SERVICE_URL"] ??
+    storageOptions.ServiceUrl;
+
+builder.Services.AddSingleton<IOptions<StorageOptions>>(Options.Create(storageOptions));
+
 // Resend transactional email (used by forgot/reset password & PIN flows).
 builder.Services.AddHttpClient<IEmailService, ResendEmailService>(client =>
 {
@@ -86,14 +100,13 @@ builder.Services.AddHttpClient<IEmailService, ResendEmailService>(client =>
 });
 
 // S3 storage for attachments (compatible with AWS S3, Cloudflare R2, MinIO)
-var s3ServiceUrl = builder.Configuration["S3_SERVICE_URL"];
-if (!string.IsNullOrWhiteSpace(s3ServiceUrl))
+if (!string.IsNullOrWhiteSpace(storageOptions.ServiceUrl))
 {
     builder.Services.AddSingleton<Amazon.S3.IAmazonS3>(sp =>
     {
         var config = new Amazon.S3.AmazonS3Config
         {
-            ServiceURL = s3ServiceUrl,
+            ServiceURL = storageOptions.ServiceUrl,
             ForcePathStyle = true
         };
         return new Amazon.S3.AmazonS3Client(
@@ -108,8 +121,7 @@ else
     {
         var config = new Amazon.S3.AmazonS3Config
         {
-            RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(
-                builder.Configuration["AWS_REGION"] ?? "ap-south-1")
+            RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(storageOptions.Region)
         };
         return new Amazon.S3.AmazonS3Client(config);
     });

--- a/apps/api/src/EduConnect.Api/appsettings.json
+++ b/apps/api/src/EduConnect.Api/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Storage": {
+    "BucketName": "educonnect-attachments",
+    "Region": "ap-south-1",
+    "PresignedUploadExpiryMinutes": 15,
+    "PresignedDownloadExpiryMinutes": 60,
+    "MaxFileSizeBytes": 10485760
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
@@ -1,0 +1,556 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Features.Attachments.DeleteAttachment;
+using EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
+using EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+public class HomeworkAttachmentFlowTests
+{
+    [Fact]
+    public void RequestUploadUrlV2Validator_AllowsWordDocumentsForHomework()
+    {
+        var validator = CreateUploadValidator();
+
+        var result = validator.Validate(
+            new RequestUploadUrlV2Command(
+                "lesson-plan.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                1024,
+                "homework"));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequestUploadUrlV2Validator_RejectsWordDocumentsForNotices()
+    {
+        var validator = CreateUploadValidator();
+
+        var result = validator.Validate(
+            new RequestUploadUrlV2Command(
+                "staff-circular.doc",
+                "application/msword",
+                1024,
+                "notice"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(error =>
+            error.ErrorMessage == "This file type is not allowed for the selected entity.");
+    }
+
+    [Fact]
+    public async Task RequestUploadUrlV2Handler_PersistsPreparedEntityTypeWithoutEntityId()
+    {
+        var schoolId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var currentUser = CreateCurrentUser(schoolId, "Teacher", teacherId);
+        var options = CreateOptions();
+
+        await SeedAsync(
+            options,
+            schoolId,
+            users:
+            [
+                CreateTeacherUser(teacherId, schoolId, "9000000040", "Teacher User", "teacher@test.com")
+            ]);
+
+        await using var context = new AppDbContext(options, currentUser);
+        var storageService = new Mock<IStorageService>(MockBehavior.Strict);
+        storageService
+            .Setup(service => service.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                "application/pdf",
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://upload.example.com");
+
+        var handler = new RequestUploadUrlV2CommandHandler(
+            context,
+            currentUser,
+            storageService.Object,
+            Options.Create(new StorageOptions()),
+            Mock.Of<ILogger<RequestUploadUrlV2CommandHandler>>());
+
+        var response = await handler.Handle(
+            new RequestUploadUrlV2Command(
+                "worksheet.pdf",
+                "application/pdf",
+                2048,
+                "homework"),
+            CancellationToken.None);
+
+        response.UploadUrl.Should().Be("https://upload.example.com");
+
+        var attachment = await context.Attachments.FirstAsync();
+        attachment.EntityId.Should().BeNull();
+        attachment.EntityType.Should().Be("homework");
+        attachment.FileName.Should().Be("worksheet.pdf");
+
+        storageService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForEntity_ParentCannotViewDraftHomeworkAttachments()
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var currentUser = CreateCurrentUser(schoolId, "Parent", parentId);
+        var options = CreateOptions();
+
+        await SeedAsync(
+            options,
+            schoolId,
+            classes:
+            [
+                CreateClass(classId, schoolId, "5", "A")
+            ],
+            users:
+            [
+                CreateTeacherUser(teacherId, schoolId, "9000000041", "Teacher", "teacher@test.com"),
+                CreateParentUser(parentId, schoolId, "9000000042", "Parent", "parent@test.com")
+            ],
+            students:
+            [
+                new StudentEntity
+                {
+                    Id = studentId,
+                    SchoolId = schoolId,
+                    ClassId = classId,
+                    RollNumber = "R001",
+                    Name = "Aarav"
+                }
+            ],
+            parentLinks:
+            [
+                new ParentStudentLinkEntity
+                {
+                    Id = Guid.NewGuid(),
+                    SchoolId = schoolId,
+                    ParentId = parentId,
+                    StudentId = studentId,
+                    Relationship = "parent"
+                }
+            ],
+            homeworks:
+            [
+                CreateHomework(homeworkId, schoolId, classId, teacherId, "Draft")
+            ],
+            attachments:
+            [
+                new AttachmentEntity
+                {
+                    Id = attachmentId,
+                    SchoolId = schoolId,
+                    EntityId = homeworkId,
+                    EntityType = "homework",
+                    StorageKey = "school/homework/file.pdf",
+                    FileName = "file.pdf",
+                    ContentType = "application/pdf",
+                    SizeBytes = 1024,
+                    UploadedById = teacherId,
+                    UploadedAt = DateTimeOffset.UtcNow
+                }
+            ]);
+
+        await using var context = new AppDbContext(options, currentUser);
+        var storageService = new Mock<IStorageService>(MockBehavior.Strict);
+        var handler = new GetAttachmentsForEntityQueryHandler(
+            context,
+            currentUser,
+            storageService.Object);
+
+        var act = () => handler.Handle(
+            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("You do not have access to these homework attachments.");
+
+        storageService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForEntity_ParentCanViewPublishedHomeworkAttachments()
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+        var currentUser = CreateCurrentUser(schoolId, "Parent", parentId);
+        var options = CreateOptions();
+
+        await SeedAsync(
+            options,
+            schoolId,
+            classes:
+            [
+                CreateClass(classId, schoolId, "6", "B")
+            ],
+            users:
+            [
+                CreateTeacherUser(teacherId, schoolId, "9000000043", "Teacher", "teacher@test.com"),
+                CreateParentUser(parentId, schoolId, "9000000044", "Parent", "parent@test.com")
+            ],
+            students:
+            [
+                new StudentEntity
+                {
+                    Id = studentId,
+                    SchoolId = schoolId,
+                    ClassId = classId,
+                    RollNumber = "R002",
+                    Name = "Ira"
+                }
+            ],
+            parentLinks:
+            [
+                new ParentStudentLinkEntity
+                {
+                    Id = Guid.NewGuid(),
+                    SchoolId = schoolId,
+                    ParentId = parentId,
+                    StudentId = studentId,
+                    Relationship = "mother"
+                }
+            ],
+            homeworks:
+            [
+                CreateHomework(homeworkId, schoolId, classId, teacherId, "Published")
+            ],
+            attachments:
+            [
+                new AttachmentEntity
+                {
+                    Id = Guid.NewGuid(),
+                    SchoolId = schoolId,
+                    EntityId = homeworkId,
+                    EntityType = "homework",
+                    StorageKey = "school/homework/file.docx",
+                    FileName = "file.docx",
+                    ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    SizeBytes = 4096,
+                    UploadedById = teacherId,
+                    UploadedAt = DateTimeOffset.UtcNow
+                }
+            ]);
+
+        await using var context = new AppDbContext(options, currentUser);
+        var storageService = new Mock<IStorageService>(MockBehavior.Strict);
+        storageService
+            .Setup(service => service.GeneratePresignedDownloadUrlAsync(
+                "school/homework/file.docx",
+                It.IsAny<TimeSpan>(),
+                "file.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://download.example.com/file.docx");
+
+        var handler = new GetAttachmentsForEntityQueryHandler(
+            context,
+            currentUser,
+            storageService.Object);
+
+        var result = await handler.Handle(
+            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
+            CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].DownloadUrl.Should().Be("https://download.example.com/file.docx");
+
+        storageService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task DeleteAttachment_TeacherCannotDeleteAttachmentFromPublishedHomework()
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var currentUser = CreateCurrentUser(schoolId, "Teacher", teacherId);
+        var options = CreateOptions();
+
+        await SeedAsync(
+            options,
+            schoolId,
+            classes:
+            [
+                CreateClass(classId, schoolId, "7", "C")
+            ],
+            users:
+            [
+                CreateTeacherUser(teacherId, schoolId, "9000000045", "Teacher", "teacher@test.com")
+            ],
+            homeworks:
+            [
+                CreateHomework(homeworkId, schoolId, classId, teacherId, "Published")
+            ],
+            attachments:
+            [
+                new AttachmentEntity
+                {
+                    Id = attachmentId,
+                    SchoolId = schoolId,
+                    EntityId = homeworkId,
+                    EntityType = "homework",
+                    StorageKey = "school/homework/file.pdf",
+                    FileName = "file.pdf",
+                    ContentType = "application/pdf",
+                    SizeBytes = 1024,
+                    UploadedById = teacherId,
+                    UploadedAt = DateTimeOffset.UtcNow
+                }
+            ]);
+
+        await using var context = new AppDbContext(options, currentUser);
+        var storageService = new Mock<IStorageService>(MockBehavior.Strict);
+        var handler = new DeleteAttachmentCommandHandler(
+            context,
+            currentUser,
+            storageService.Object,
+            Mock.Of<ILogger<DeleteAttachmentCommandHandler>>());
+
+        var act = () => handler.Handle(new DeleteAttachmentCommand(attachmentId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("Attachments can only be deleted while homework is editable.");
+
+        storageService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task DeleteAttachment_TeacherCanDeleteAttachmentFromDraftHomework()
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var currentUser = CreateCurrentUser(schoolId, "Teacher", teacherId);
+        var options = CreateOptions();
+
+        await SeedAsync(
+            options,
+            schoolId,
+            classes:
+            [
+                CreateClass(classId, schoolId, "8", "A")
+            ],
+            users:
+            [
+                CreateTeacherUser(teacherId, schoolId, "9000000046", "Teacher", "teacher@test.com")
+            ],
+            homeworks:
+            [
+                CreateHomework(homeworkId, schoolId, classId, teacherId, "Draft")
+            ],
+            attachments:
+            [
+                new AttachmentEntity
+                {
+                    Id = attachmentId,
+                    SchoolId = schoolId,
+                    EntityId = homeworkId,
+                    EntityType = "homework",
+                    StorageKey = "school/homework/file.pdf",
+                    FileName = "file.pdf",
+                    ContentType = "application/pdf",
+                    SizeBytes = 1024,
+                    UploadedById = teacherId,
+                    UploadedAt = DateTimeOffset.UtcNow
+                }
+            ]);
+
+        await using var context = new AppDbContext(options, currentUser);
+        var storageService = new Mock<IStorageService>(MockBehavior.Strict);
+        storageService
+            .Setup(service => service.DeleteObjectAsync("school/homework/file.pdf", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new DeleteAttachmentCommandHandler(
+            context,
+            currentUser,
+            storageService.Object,
+            Mock.Of<ILogger<DeleteAttachmentCommandHandler>>());
+
+        var response = await handler.Handle(
+            new DeleteAttachmentCommand(attachmentId),
+            CancellationToken.None);
+
+        response.Message.Should().Be("Attachment deleted successfully.");
+        (await context.Attachments.AnyAsync(a => a.Id == attachmentId)).Should().BeFalse();
+        storageService.VerifyAll();
+    }
+
+    private static RequestUploadUrlV2CommandValidator CreateUploadValidator()
+    {
+        return new RequestUploadUrlV2CommandValidator(
+            Options.Create(new StorageOptions()));
+    }
+
+    private static DbContextOptions<AppDbContext> CreateOptions()
+    {
+        return new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"HomeworkAttachment_{Guid.NewGuid()}")
+            .Options;
+    }
+
+    private static CurrentUserService CreateCurrentUser(Guid schoolId, string role, Guid? userId = null)
+    {
+        return new CurrentUserService
+        {
+            UserId = userId ?? Guid.NewGuid(),
+            SchoolId = schoolId,
+            Role = role,
+            Name = $"{role} User"
+        };
+    }
+
+    private static ClassEntity CreateClass(Guid classId, Guid schoolId, string name, string section)
+    {
+        return new ClassEntity
+        {
+            Id = classId,
+            SchoolId = schoolId,
+            Name = name,
+            Section = section,
+            AcademicYear = "2026-27"
+        };
+    }
+
+    private static HomeworkEntity CreateHomework(
+        Guid homeworkId,
+        Guid schoolId,
+        Guid classId,
+        Guid teacherId,
+        string status)
+    {
+        return new HomeworkEntity
+        {
+            Id = homeworkId,
+            SchoolId = schoolId,
+            ClassId = classId,
+            Subject = "Science",
+            Title = "Homework",
+            Description = "Practice work",
+            AssignedById = teacherId,
+            DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(3)),
+            Status = status,
+            PublishedAt = status == "Published" ? DateTimeOffset.UtcNow : null,
+            SubmittedAt = status == "PendingApproval" ? DateTimeOffset.UtcNow : null,
+            IsEditable = status == "Draft" || status == "Rejected"
+        };
+    }
+
+    private static UserEntity CreateTeacherUser(Guid id, Guid schoolId, string phone, string name, string email)
+    {
+        return new UserEntity
+        {
+            Id = id,
+            SchoolId = schoolId,
+            Phone = phone,
+            Email = email,
+            Name = name,
+            Role = "Teacher",
+            PasswordHash = "hashed",
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static UserEntity CreateParentUser(Guid id, Guid schoolId, string phone, string name, string email)
+    {
+        return new UserEntity
+        {
+            Id = id,
+            SchoolId = schoolId,
+            Phone = phone,
+            Email = email,
+            Name = name,
+            Role = "Parent",
+            PinHash = "hashed",
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static async Task SeedAsync(
+        DbContextOptions<AppDbContext> options,
+        Guid schoolId,
+        IEnumerable<ClassEntity>? classes = null,
+        IEnumerable<UserEntity>? users = null,
+        IEnumerable<StudentEntity>? students = null,
+        IEnumerable<ParentStudentLinkEntity>? parentLinks = null,
+        IEnumerable<HomeworkEntity>? homeworks = null,
+        IEnumerable<AttachmentEntity>? attachments = null)
+    {
+        await using var context = new AppDbContext(options);
+
+        context.Schools.Add(new SchoolEntity
+        {
+            Id = schoolId,
+            Name = "Test School",
+            Code = $"SCH-{schoolId.ToString()[..6]}",
+            Address = "Test Address",
+            ContactPhone = "9999999999",
+            ContactEmail = "school@test.com",
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        if (classes != null)
+        {
+            context.Classes.AddRange(classes);
+        }
+
+        if (users != null)
+        {
+            context.Users.AddRange(users);
+        }
+
+        if (students != null)
+        {
+            context.Students.AddRange(students);
+        }
+
+        if (parentLinks != null)
+        {
+            context.ParentStudentLinks.AddRange(parentLinks);
+        }
+
+        if (homeworks != null)
+        {
+            context.Homeworks.AddRange(homeworks);
+        }
+
+        if (attachments != null)
+        {
+            context.Attachments.AddRange(attachments);
+        }
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/apps/web/app/(dashboard)/teacher/homework/page.tsx
+++ b/apps/web/app/(dashboard)/teacher/homework/page.tsx
@@ -16,6 +16,7 @@ import { StatusBanner } from "@/components/shared/status-banner";
 import { BookOpen, Pencil, Plus } from "lucide-react";
 import { AttachmentUploader, type UploadedFile } from "@/components/shared/attachment-uploader";
 import { AttachmentList } from "@/components/shared/attachment-list";
+import type { AttachmentItem } from "@/lib/types/attachment";
 
 interface HomeworkItem {
   homeworkId: string;
@@ -77,6 +78,12 @@ export default function TeacherHomeworkPage(): React.ReactElement {
   // Post-create attachment flow
   const [newHomeworkId, setNewHomeworkId] = React.useState<string | null>(null);
   const [newHomeworkAttachments, setNewHomeworkAttachments] = React.useState<UploadedFile[]>([]);
+  const [managingAttachmentsForId, setManagingAttachmentsForId] = React.useState<string | null>(null);
+  const [loadingAttachmentsForId, setLoadingAttachmentsForId] = React.useState<string | null>(null);
+  const [attachmentError, setAttachmentError] = React.useState("");
+  const [attachmentsByHomeworkId, setAttachmentsByHomeworkId] = React.useState<
+    Record<string, UploadedFile[]>
+  >({});
 
   const fetchHomework = React.useCallback(async () => {
     setIsLoading(true);
@@ -94,6 +101,61 @@ export default function TeacherHomeworkPage(): React.ReactElement {
   React.useEffect(() => {
     fetchHomework();
   }, [fetchHomework]);
+
+  const mapAttachments = React.useCallback(
+    (attachments: AttachmentItem[]): UploadedFile[] =>
+      attachments.map((attachment) => ({
+        attachmentId: attachment.id,
+        fileName: attachment.fileName,
+        contentType: attachment.contentType,
+        sizeBytes: attachment.sizeBytes,
+      })),
+    []
+  );
+
+  const loadHomeworkAttachments = React.useCallback(
+    async (homeworkId: string): Promise<void> => {
+      setLoadingAttachmentsForId(homeworkId);
+      setAttachmentError("");
+
+      try {
+        const attachments = await apiGet<AttachmentItem[]>(
+          `${API_ENDPOINTS.attachments}?entityId=${homeworkId}&entityType=homework`
+        );
+
+        setAttachmentsByHomeworkId((prev) => ({
+          ...prev,
+          [homeworkId]: mapAttachments(attachments),
+        }));
+      } catch (err) {
+        setAttachmentError(
+          err instanceof ApiError ? err.message : "Failed to load attachments."
+        );
+      } finally {
+        setLoadingAttachmentsForId((current) =>
+          current === homeworkId ? null : current
+        );
+      }
+    },
+    [mapAttachments]
+  );
+
+  const toggleAttachmentManager = React.useCallback(
+    async (homeworkId: string): Promise<void> => {
+      if (managingAttachmentsForId === homeworkId) {
+        setManagingAttachmentsForId(null);
+        setAttachmentError("");
+        return;
+      }
+
+      setManagingAttachmentsForId(homeworkId);
+
+      if (!attachmentsByHomeworkId[homeworkId]) {
+        await loadHomeworkAttachments(homeworkId);
+      }
+    },
+    [attachmentsByHomeworkId, loadHomeworkAttachments, managingAttachmentsForId]
+  );
 
   const handleCreate = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
@@ -285,7 +347,7 @@ export default function TeacherHomeworkPage(): React.ReactElement {
           <div>
             <h3 className="text-lg font-semibold">Attach Files to Homework</h3>
             <p className="mt-1 text-sm text-muted-foreground">
-              Optionally attach images or PDFs to the homework you just created.
+              Optionally attach PDF or Word documents to the homework you just created.
             </p>
           </div>
           <AttachmentUploader
@@ -523,26 +585,73 @@ export default function TeacherHomeworkPage(): React.ReactElement {
                     <span className="text-muted-foreground">Due:</span>
                     <span className="font-medium">{formatDate(item.dueDate)}</span>
                   </div>
-                  {item.canSubmitForApproval && (
-                    <div className="mb-3 flex flex-wrap gap-2">
-                      <Button
-                        size="sm"
-                        onClick={() => submitForApproval(item.homeworkId)}
-                        disabled={actionHomeworkId === item.homeworkId}
-                      >
-                        {actionHomeworkId === item.homeworkId ? <Spinner size="sm" /> : "Submit for approval"}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => startEdit(item)}
-                        disabled={actionHomeworkId === item.homeworkId}
-                      >
-                        Edit draft
-                      </Button>
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap gap-2">
+                      {item.canSubmitForApproval && (
+                        <>
+                          <Button
+                            size="sm"
+                            onClick={() => submitForApproval(item.homeworkId)}
+                            disabled={actionHomeworkId === item.homeworkId}
+                          >
+                            {actionHomeworkId === item.homeworkId ? (
+                              <Spinner size="sm" />
+                            ) : (
+                              "Submit for approval"
+                            )}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => startEdit(item)}
+                            disabled={actionHomeworkId === item.homeworkId}
+                          >
+                            Edit draft
+                          </Button>
+                        </>
+                      )}
+
+                      {item.isEditable && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            void toggleAttachmentManager(item.homeworkId);
+                          }}
+                          disabled={loadingAttachmentsForId === item.homeworkId}
+                        >
+                          {loadingAttachmentsForId === item.homeworkId ? (
+                            <Spinner size="sm" />
+                          ) : managingAttachmentsForId === item.homeworkId ? (
+                            "Hide attachments"
+                          ) : (
+                            "Manage attachments"
+                          )}
+                        </Button>
+                      )}
                     </div>
-                  )}
-                  <AttachmentList entityId={item.homeworkId} entityType="homework" />
+
+                    {item.isEditable && managingAttachmentsForId === item.homeworkId ? (
+                      <div className="space-y-3">
+                        {attachmentError ? (
+                          <StatusBanner variant="error">{attachmentError}</StatusBanner>
+                        ) : null}
+                        <AttachmentUploader
+                          entityId={item.homeworkId}
+                          entityType="homework"
+                          existingAttachments={attachmentsByHomeworkId[item.homeworkId] ?? []}
+                          onAttachmentsChange={(attachments) => {
+                            setAttachmentsByHomeworkId((prev) => ({
+                              ...prev,
+                              [item.homeworkId]: attachments,
+                            }));
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      <AttachmentList entityId={item.homeworkId} entityType="homework" />
+                    )}
+                  </div>
                 </CardContent>
               </Card>
             )

--- a/apps/web/components/shared/attachment-list.tsx
+++ b/apps/web/components/shared/attachment-list.tsx
@@ -4,13 +4,17 @@ import * as React from "react";
 import { ApiError, apiGet } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
 import { Spinner } from "@/components/ui/spinner";
-import { FileText, ImageIcon, Download, Paperclip } from "lucide-react";
-import { formatFileSize } from "@/lib/types/attachment";
-import type { AttachmentItem } from "@/lib/types/attachment";
+import { Download, FileText, ImageIcon, Paperclip } from "lucide-react";
+import type { AttachmentEntityType, AttachmentItem } from "@/lib/types/attachment";
+import {
+  formatFileSize,
+  isPdfAttachment,
+  isWordAttachment,
+} from "@/lib/types/attachment";
 
 interface AttachmentListProps {
   entityId: string;
-  entityType: "homework" | "notice";
+  entityType: AttachmentEntityType;
 }
 
 export function AttachmentList({
@@ -24,6 +28,7 @@ export function AttachmentList({
   const fetchAttachments = React.useCallback(async () => {
     setIsLoading(true);
     setError("");
+
     try {
       const data = await apiGet<AttachmentItem[]>(
         `${API_ENDPOINTS.attachments}?entityId=${entityId}&entityType=${entityType}`
@@ -31,9 +36,7 @@ export function AttachmentList({
       setAttachments(data);
     } catch (err) {
       setError(
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load attachments."
+        err instanceof ApiError ? err.message : "Failed to load attachments."
       );
     } finally {
       setIsLoading(false);
@@ -41,7 +44,7 @@ export function AttachmentList({
   }, [entityId, entityType]);
 
   React.useEffect(() => {
-    fetchAttachments();
+    void fetchAttachments();
   }, [fetchAttachments]);
 
   if (isLoading) {
@@ -56,9 +59,7 @@ export function AttachmentList({
   }
 
   if (error) {
-    return (
-      <p className="text-sm text-destructive">{error}</p>
-    );
+    return <p className="text-sm text-destructive">{error}</p>;
   }
 
   if (attachments.length === 0) {
@@ -66,10 +67,15 @@ export function AttachmentList({
   }
 
   const getFileIcon = (contentType: string): React.ReactNode => {
-    if (contentType === "application/pdf") {
-      return <FileText className="h-4 w-4 text-red-500" aria-hidden="true" />;
+    if (isWordAttachment(contentType)) {
+      return <FileText className="h-4 w-4 text-sky-600" aria-hidden="true" />;
     }
-    return <ImageIcon className="h-4 w-4 text-blue-500" aria-hidden="true" />;
+
+    if (isPdfAttachment(contentType)) {
+      return <FileText className="h-4 w-4 text-rose-600" aria-hidden="true" />;
+    }
+
+    return <ImageIcon className="h-4 w-4 text-emerald-600" aria-hidden="true" />;
   };
 
   return (
@@ -84,31 +90,36 @@ export function AttachmentList({
         </p>
       </div>
       <div className="space-y-1.5">
-        {attachments.map((attachment) => (
-          <a
-            key={attachment.id}
-            href={attachment.downloadUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-3 rounded-[20px] border border-border/70 bg-card/72 p-3 shadow-[0_14px_30px_-28px_rgba(15,23,42,0.4)] transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:bg-card/92 dark:bg-card/86"
-          >
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-secondary/70">
-              {getFileIcon(attachment.contentType)}
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-foreground">
-                {attachment.fileName}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {formatFileSize(attachment.sizeBytes)}
-              </p>
-            </div>
-            <Download
-              className="h-4 w-4 shrink-0 text-muted-foreground"
-              aria-hidden="true"
-            />
-          </a>
-        ))}
+        {attachments.map((attachment) => {
+          const opensInNewTab = !isWordAttachment(attachment.contentType);
+
+          return (
+            <a
+              key={attachment.id}
+              href={attachment.downloadUrl}
+              target={opensInNewTab ? "_blank" : undefined}
+              rel={opensInNewTab ? "noopener noreferrer" : undefined}
+              className="flex items-center gap-3 rounded-[20px] border border-border/70 bg-card/72 p-3 shadow-[0_14px_30px_-28px_rgba(15,23,42,0.4)] transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:bg-card/92 dark:bg-card/86"
+              aria-label={`Download ${attachment.fileName}`}
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-secondary/70">
+                {getFileIcon(attachment.contentType)}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {attachment.fileName}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(attachment.sizeBytes)}
+                </p>
+              </div>
+              <Download
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+            </a>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/components/shared/attachment-uploader.tsx
+++ b/apps/web/components/shared/attachment-uploader.tsx
@@ -1,23 +1,30 @@
 "use client";
 
 import * as React from "react";
-import { ApiError, apiPost, apiDelete } from "@/lib/api-client";
+import { useDropzone, type FileRejection } from "react-dropzone";
+import { AlertCircle, CheckCircle2, FileText, ImageIcon, UploadCloud, X } from "lucide-react";
+import { ApiError, apiDelete, apiPost } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
-import { FileUp, X, FileText, ImageIcon, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
-  RequestUploadUrlRequest,
-  RequestUploadUrlResponse,
   AttachFileRequest,
   AttachFileResponse,
+  AttachmentEntityType,
   DeleteAttachmentResponse,
+  RequestUploadUrlRequest,
+  RequestUploadUrlResponse,
 } from "@/lib/types/attachment";
 import {
-  isAllowedContentType,
-  formatFileSize,
-  MAX_FILE_SIZE_BYTES,
   MAX_ATTACHMENTS_PER_ENTITY,
+  MAX_FILE_SIZE_BYTES,
+  formatFileSize,
+  getAcceptedFiles,
+  getAttachmentEmptyLabel,
+  getAttachmentHelperText,
+  isAllowedContentType,
+  isPdfAttachment,
+  isWordAttachment,
 } from "@/lib/types/attachment";
 
 export interface UploadedFile {
@@ -33,15 +40,44 @@ interface FileInProgress {
   progress: number;
   status: "uploading" | "attaching" | "done" | "error";
   error?: string;
-  attachmentId?: string;
 }
 
 interface AttachmentUploaderProps {
   entityId: string;
-  entityType: "homework" | "notice";
+  entityType: AttachmentEntityType;
   existingAttachments?: UploadedFile[];
   onAttachmentsChange: (attachments: UploadedFile[]) => void;
   disabled?: boolean;
+}
+
+function uploadToPresignedUrl(
+  uploadUrl: string,
+  file: File,
+  onProgress: (progress: number) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PUT", uploadUrl);
+    xhr.setRequestHeader("Content-Type", file.type);
+
+    xhr.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      onProgress(Math.min(95, Math.round((event.loaded / event.total) * 100)));
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        onProgress(100);
+        resolve();
+        return;
+      }
+
+      reject(new Error("Failed to upload file to storage."));
+    };
+
+    xhr.onerror = () => reject(new Error("Network error during upload."));
+    xhr.send(file);
+  });
 }
 
 export function AttachmentUploader({
@@ -51,343 +87,418 @@ export function AttachmentUploader({
   onAttachmentsChange,
   disabled = false,
 }: AttachmentUploaderProps): React.ReactElement {
-  const [filesInProgress, setFilesInProgress] = React.useState<
-    FileInProgress[]
-  >([]);
-  const [isDragOver, setIsDragOver] = React.useState(false);
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const attachmentsRef = React.useRef(existingAttachments);
+  const [filesInProgress, setFilesInProgress] = React.useState<FileInProgress[]>(
+    []
+  );
+  const [confirmingDeleteId, setConfirmingDeleteId] = React.useState<string | null>(
+    null
+  );
+  const [deleteError, setDeleteError] = React.useState<string>("");
+
+  React.useEffect(() => {
+    attachmentsRef.current = existingAttachments;
+  }, [existingAttachments]);
 
   const totalAttached = existingAttachments.length;
   const canAddMore = totalAttached < MAX_ATTACHMENTS_PER_ENTITY;
+  const remainingSlots = Math.max(0, MAX_ATTACHMENTS_PER_ENTITY - totalAttached);
 
-  const handleFiles = React.useCallback(
-    async (files: FileList | File[]) => {
-      const fileArray = Array.from(files);
-      const remaining = MAX_ATTACHMENTS_PER_ENTITY - totalAttached;
+  const updateProgressItem = React.useCallback(
+    (trackingId: string, next: Partial<FileInProgress>): void => {
+      setFilesInProgress((prev) =>
+        prev.map((file) => (file.id === trackingId ? { ...file, ...next } : file))
+      );
+    },
+    []
+  );
 
-      if (fileArray.length > remaining) {
-        fileArray.splice(remaining);
+  const addFileError = React.useCallback((file: File, error: string): void => {
+    setFilesInProgress((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        file,
+        progress: 0,
+        status: "error",
+        error,
+      },
+    ]);
+  }, []);
+
+  const uploadFile = React.useCallback(
+    async (file: File): Promise<void> => {
+      const trackingId = crypto.randomUUID();
+
+      setFilesInProgress((prev) => [
+        ...prev,
+        {
+          id: trackingId,
+          file,
+          progress: 0,
+          status: "uploading",
+        },
+      ]);
+
+      try {
+        const body: RequestUploadUrlRequest = {
+          fileName: file.name,
+          contentType: file.type,
+          sizeBytes: file.size,
+          entityType,
+        };
+
+        const uploadUrlResponse = await apiPost<RequestUploadUrlResponse>(
+          API_ENDPOINTS.attachmentsRequestUploadV2,
+          body
+        );
+
+        updateProgressItem(trackingId, { progress: 10 });
+
+        await uploadToPresignedUrl(uploadUrlResponse.uploadUrl, file, (progress) => {
+          updateProgressItem(trackingId, { progress });
+        });
+
+        updateProgressItem(trackingId, { progress: 100, status: "attaching" });
+
+        const attachBody: AttachFileRequest = {
+          attachmentId: uploadUrlResponse.attachmentId,
+          entityId,
+          entityType,
+        };
+
+        await apiPost<AttachFileResponse>(API_ENDPOINTS.attachmentsAttach, attachBody);
+
+        updateProgressItem(trackingId, { progress: 100, status: "done" });
+
+        const nextAttachments = [
+          ...attachmentsRef.current,
+          {
+            attachmentId: uploadUrlResponse.attachmentId,
+            fileName: file.name,
+            contentType: file.type,
+            sizeBytes: file.size,
+          },
+        ];
+
+        attachmentsRef.current = nextAttachments;
+        onAttachmentsChange(nextAttachments);
+
+        window.setTimeout(() => {
+          setFilesInProgress((prev) => prev.filter((item) => item.id !== trackingId));
+        }, 1200);
+      } catch (error) {
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : error instanceof Error
+              ? error.message
+              : "Upload failed.";
+
+        updateProgressItem(trackingId, {
+          status: "error",
+          error: message,
+        });
+      }
+    },
+    [entityId, entityType, onAttachmentsChange, updateProgressItem]
+  );
+
+  const handleAcceptedFiles = React.useCallback(
+    async (acceptedFiles: File[]) => {
+      setDeleteError("");
+
+      const remaining = MAX_ATTACHMENTS_PER_ENTITY - existingAttachments.length;
+      const filesToUpload = acceptedFiles.slice(0, remaining);
+
+      if (acceptedFiles.length > remaining) {
+        acceptedFiles.slice(remaining).forEach((file) => {
+          addFileError(
+            file,
+            `Maximum ${MAX_ATTACHMENTS_PER_ENTITY} attachments allowed per ${entityType}.`
+          );
+        });
       }
 
-      for (const file of fileArray) {
-        if (!isAllowedContentType(file.type)) {
-          setFilesInProgress((prev) => [
-            ...prev,
-            {
-              id: crypto.randomUUID(),
-              file,
-              progress: 0,
-              status: "error",
-              error: "Unsupported file type. Use JPEG, PNG, WebP, or PDF.",
-            },
-          ]);
+      for (const file of filesToUpload) {
+        if (!isAllowedContentType(entityType, file.type)) {
+          addFileError(
+            file,
+            entityType === "homework"
+              ? "Only PDF and Word documents are allowed."
+              : "Only JPEG, PNG, WebP, and PDF files are allowed."
+          );
           continue;
         }
 
         if (file.size > MAX_FILE_SIZE_BYTES) {
-          setFilesInProgress((prev) => [
-            ...prev,
-            {
-              id: crypto.randomUUID(),
-              file,
-              progress: 0,
-              status: "error",
-              error: `File too large (${formatFileSize(file.size)}). Max 10MB.`,
-            },
-          ]);
+          addFileError(
+            file,
+            `File too large (${formatFileSize(file.size)}). Max 10MB.`
+          );
           continue;
         }
 
-        const trackingId = crypto.randomUUID();
-
-        setFilesInProgress((prev) => [
-          ...prev,
-          { id: trackingId, file, progress: 0, status: "uploading" },
-        ]);
-
-        try {
-          // Step 1: Request presigned upload URL
-          const body: RequestUploadUrlRequest = {
-            fileName: file.name,
-            contentType: file.type,
-            sizeBytes: file.size,
-          };
-
-          const uploadUrlResponse = await apiPost<RequestUploadUrlResponse>(
-            API_ENDPOINTS.attachmentsRequestUpload,
-            body
-          );
-
-          setFilesInProgress((prev) =>
-            prev.map((f) =>
-              f.id === trackingId
-                ? {
-                    ...f,
-                    progress: 30,
-                    attachmentId: uploadUrlResponse.attachmentId,
-                  }
-                : f
-            )
-          );
-
-          // Step 2: Upload file directly to S3 via presigned URL
-          const uploadResponse = await fetch(uploadUrlResponse.uploadUrl, {
-            method: "PUT",
-            headers: { "Content-Type": file.type },
-            body: file,
-          });
-
-          if (!uploadResponse.ok) {
-            throw new Error("Failed to upload file to storage.");
-          }
-
-          setFilesInProgress((prev) =>
-            prev.map((f) =>
-              f.id === trackingId
-                ? { ...f, progress: 70, status: "attaching" }
-                : f
-            )
-          );
-
-          // Step 3: Attach to entity
-          const attachBody: AttachFileRequest = {
-            attachmentId: uploadUrlResponse.attachmentId,
-            entityId,
-            entityType,
-          };
-
-          await apiPost<AttachFileResponse>(
-            API_ENDPOINTS.attachmentsAttach,
-            attachBody
-          );
-
-          setFilesInProgress((prev) =>
-            prev.map((f) =>
-              f.id === trackingId ? { ...f, progress: 100, status: "done" } : f
-            )
-          );
-
-          // Add to parent's attached list
-          const newAttachment: UploadedFile = {
-            attachmentId: uploadUrlResponse.attachmentId,
-            fileName: file.name,
-            contentType: file.type,
-            sizeBytes: file.size,
-          };
-
-          onAttachmentsChange([...existingAttachments, newAttachment]);
-
-          // Remove from progress list after a short delay
-          setTimeout(() => {
-            setFilesInProgress((prev) =>
-              prev.filter((f) => f.id !== trackingId)
-            );
-          }, 1500);
-        } catch (err) {
-          const errorMessage =
-            err instanceof ApiError
-              ? err.message
-              : err instanceof Error
-                ? err.message
-                : "Upload failed.";
-
-          setFilesInProgress((prev) =>
-            prev.map((f) =>
-              f.id === trackingId
-                ? { ...f, status: "error", error: errorMessage }
-                : f
-            )
-          );
-        }
+        await uploadFile(file);
       }
     },
-    [entityId, entityType, existingAttachments, onAttachmentsChange, totalAttached]
+    [addFileError, entityType, existingAttachments.length, uploadFile]
   );
 
-  const handleDrop = React.useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragOver(false);
-      if (disabled || !canAddMore) return;
-      void handleFiles(e.dataTransfer.files);
+  const onDropRejected = React.useCallback(
+    (rejections: FileRejection[]) => {
+      rejections.forEach(({ file, errors }) => {
+        const firstError = errors[0];
+
+        if (firstError?.code === "too-many-files") {
+          addFileError(
+            file,
+            `Maximum ${MAX_ATTACHMENTS_PER_ENTITY} attachments allowed per ${entityType}.`
+          );
+          return;
+        }
+
+        if (firstError?.code === "file-too-large") {
+          addFileError(
+            file,
+            `File too large (${formatFileSize(file.size)}). Max 10MB.`
+          );
+          return;
+        }
+
+        addFileError(
+          file,
+          entityType === "homework"
+            ? "Only PDF and Word documents are allowed."
+            : "Only JPEG, PNG, WebP, and PDF files are allowed."
+        );
+      });
     },
-    [disabled, canAddMore, handleFiles]
+    [addFileError, entityType]
   );
 
-  const handleDragOver = (e: React.DragEvent): void => {
-    e.preventDefault();
-    if (!disabled && canAddMore) {
-      setIsDragOver(true);
-    }
-  };
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    accept: getAcceptedFiles(entityType),
+    disabled: disabled || !canAddMore,
+    maxFiles: remainingSlots,
+    maxSize: MAX_FILE_SIZE_BYTES,
+    multiple: true,
+    noClick: true,
+    noKeyboard: true,
+    onDropAccepted: (acceptedFiles) => {
+      void handleAcceptedFiles(acceptedFiles);
+    },
+    onDropRejected,
+  });
 
-  const handleDragLeave = (e: React.DragEvent): void => {
-    e.preventDefault();
-    setIsDragOver(false);
-  };
+  const handleRemoveAttachment = async (attachmentId: string): Promise<void> => {
+    setDeleteError("");
 
-  const handleBrowse = (): void => {
-    fileInputRef.current?.click();
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    if (e.target.files && e.target.files.length > 0) {
-      void handleFiles(e.target.files);
-      e.target.value = "";
-    }
-  };
-
-  const handleRemoveAttachment = async (
-    attachmentId: string
-  ): Promise<void> => {
     try {
       await apiDelete<DeleteAttachmentResponse>(
         `${API_ENDPOINTS.attachments}/${attachmentId}`
       );
-      onAttachmentsChange(
-        existingAttachments.filter((a) => a.attachmentId !== attachmentId)
+
+      const nextAttachments = attachmentsRef.current.filter(
+        (attachment) => attachment.attachmentId !== attachmentId
       );
-    } catch {
-      // Silently fail — UI stays consistent
+
+      attachmentsRef.current = nextAttachments;
+      onAttachmentsChange(nextAttachments);
+      setConfirmingDeleteId(null);
+    } catch (error) {
+      setDeleteError(
+        error instanceof ApiError ? error.message : "Failed to delete attachment."
+      );
     }
   };
 
-  const handleDismissError = (trackingId: string): void => {
-    setFilesInProgress((prev) => prev.filter((f) => f.id !== trackingId));
+  const dismissProgressItem = (trackingId: string): void => {
+    setFilesInProgress((prev) => prev.filter((file) => file.id !== trackingId));
   };
 
   const getFileIcon = (contentType: string): React.ReactNode => {
-    if (contentType === "application/pdf") {
-      return <FileText className="h-4 w-4 text-red-500" aria-hidden="true" />;
+    if (isWordAttachment(contentType)) {
+      return <FileText className="h-5 w-5 text-sky-600" aria-hidden="true" />;
     }
-    return <ImageIcon className="h-4 w-4 text-blue-500" aria-hidden="true" />;
+
+    if (isPdfAttachment(contentType)) {
+      return <FileText className="h-5 w-5 text-rose-600" aria-hidden="true" />;
+    }
+
+    return <ImageIcon className="h-5 w-5 text-emerald-600" aria-hidden="true" />;
   };
 
   return (
-    <div className="space-y-3">
-      {/* Drop zone */}
+    <div className="space-y-4">
       <div
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        className={cn(
-          "flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-6 transition-colors",
-          isDragOver
-            ? "border-primary bg-primary/5"
-            : "border-border bg-muted/30",
-          (disabled || !canAddMore) && "cursor-not-allowed opacity-50"
-        )}
+        {...getRootProps({
+          className: cn(
+            "rounded-[24px] border-2 border-dashed p-5 text-center transition-colors",
+            isDragActive
+              ? "border-primary bg-primary/5"
+              : "border-border bg-muted/30",
+            (disabled || !canAddMore) && "cursor-not-allowed opacity-60"
+          ),
+          role: "button",
+          tabIndex: disabled || !canAddMore ? -1 : 0,
+          "aria-label": `Upload ${entityType} attachments`,
+          onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              if (!disabled && canAddMore) {
+                open();
+              }
+            }
+          },
+        })}
       >
-        <FileUp
-          className="mb-2 h-6 w-6 text-muted-foreground"
-          aria-hidden="true"
-        />
-        <p className="text-sm text-muted-foreground">
+        <input {...getInputProps()} />
+        <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-card/80 shadow-[0_14px_32px_-26px_rgba(15,23,42,0.35)]">
+          <UploadCloud className="h-6 w-6 text-primary" aria-hidden="true" />
+        </div>
+        <p className="text-sm font-medium text-foreground">
           {canAddMore
-            ? "Drag & drop files here, or"
-            : `Maximum ${MAX_ATTACHMENTS_PER_ENTITY} files reached`}
+            ? getAttachmentEmptyLabel(entityType)
+            : `Maximum ${MAX_ATTACHMENTS_PER_ENTITY} attachments reached`}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {getAttachmentHelperText(entityType)}
         </p>
         {canAddMore && (
           <Button
             type="button"
-            variant="link"
+            variant="outline"
             size="sm"
-            onClick={handleBrowse}
+            onClick={open}
             disabled={disabled}
-            className="mt-1"
+            className="mt-4"
           >
             Browse files
           </Button>
         )}
-        <p className="mt-1 text-xs text-muted-foreground">
-          JPEG, PNG, WebP, or PDF — max 10MB each
-        </p>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp,application/pdf"
-          multiple
-          onChange={handleInputChange}
-          className="hidden"
-          disabled={disabled || !canAddMore}
-        />
       </div>
 
-      {/* Upload progress */}
-      {filesInProgress.map((f) => (
-        <div
-          key={f.id}
-          className={cn(
-            "flex items-center gap-3 rounded-md border p-3",
-            f.status === "error" && "border-destructive/50 bg-destructive/5"
-          )}
-        >
-          {f.status === "error" ? (
-            <AlertCircle
-              className="h-4 w-4 shrink-0 text-destructive"
-              aria-hidden="true"
-            />
-          ) : (
-            getFileIcon(f.file.type)
-          )}
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium">{f.file.name}</p>
-            {f.status === "error" ? (
-              <p className="text-xs text-destructive">{f.error}</p>
-            ) : (
-              <div className="mt-1 h-1.5 w-full rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-300"
-                  style={{ width: `${f.progress}%` }}
-                />
-              </div>
-            )}
-          </div>
-          {f.status === "error" && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 shrink-0"
-              onClick={() => handleDismissError(f.id)}
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          )}
-        </div>
-      ))}
+      {(filesInProgress.length > 0 || deleteError) && (
+        <div className="space-y-3">
+          {deleteError ? (
+            <div className="rounded-[20px] border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {deleteError}
+            </div>
+          ) : null}
 
-      {/* Attached files */}
-      {existingAttachments.length > 0 && (
-        <div className="space-y-2">
-          <p className="text-xs font-medium text-muted-foreground">
-            {existingAttachments.length} / {MAX_ATTACHMENTS_PER_ENTITY} files
-            attached
-          </p>
-          {existingAttachments.map((a) => (
+          {filesInProgress.map((file) => (
             <div
-              key={a.attachmentId}
-              className="flex items-center gap-3 rounded-md border p-3"
+              key={file.id}
+              className={cn(
+                "flex items-center gap-3 rounded-[22px] border border-border/70 bg-card/82 p-3 shadow-[0_14px_30px_-28px_rgba(15,23,42,0.35)]",
+                file.status === "error" && "border-destructive/40 bg-destructive/10"
+              )}
             >
-              {getFileIcon(a.contentType)}
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{a.fileName}</p>
-                <p className="text-xs text-muted-foreground">
-                  {formatFileSize(a.sizeBytes)}
-                </p>
+              <div className="shrink-0">
+                {file.status === "done" ? (
+                  <CheckCircle2
+                    className="h-5 w-5 text-emerald-600"
+                    aria-hidden="true"
+                  />
+                ) : file.status === "error" ? (
+                  <AlertCircle
+                    className="h-5 w-5 text-destructive"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  getFileIcon(file.file.type)
+                )}
               </div>
-              {!disabled && (
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {file.file.name}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(file.file.size)}
+                </p>
+                {file.status === "error" ? (
+                  <p className="mt-1 text-xs text-destructive">{file.error}</p>
+                ) : (
+                  <div className="mt-2 h-1.5 w-full rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-primary transition-all duration-300"
+                      style={{ width: `${file.progress}%` }}
+                    />
+                  </div>
+                )}
+              </div>
+              {file.status === "error" && (
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
-                  onClick={() => {
-                    void handleRemoveAttachment(a.attachmentId);
-                  }}
-                  aria-label={`Remove ${a.fileName}`}
+                  className="h-8 w-8 shrink-0"
+                  onClick={() => dismissProgressItem(file.id)}
+                  aria-label={`Dismiss error for ${file.file.name}`}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {existingAttachments.length > 0 && (
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            {existingAttachments.length} / {MAX_ATTACHMENTS_PER_ENTITY} attached
+          </p>
+          {existingAttachments.map((attachment) => (
+            <div
+              key={attachment.attachmentId}
+              className="flex items-center gap-3 rounded-[22px] border border-border/70 bg-card/82 p-3 shadow-[0_14px_30px_-28px_rgba(15,23,42,0.35)]"
+            >
+              <div className="shrink-0">{getFileIcon(attachment.contentType)}</div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {attachment.fileName}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {formatFileSize(attachment.sizeBytes)}
+                </p>
+              </div>
+
+              {disabled ? null : confirmingDeleteId === attachment.attachmentId ? (
+                <div className="flex items-center gap-2 rounded-full bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive">
+                  <span>Delete?</span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 rounded-full px-2 text-destructive hover:text-destructive"
+                    onClick={() => {
+                      void handleRemoveAttachment(attachment.attachmentId);
+                    }}
+                  >
+                    Yes
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 rounded-full px-2"
+                    onClick={() => setConfirmingDeleteId(null)}
+                  >
+                    No
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmingDeleteId(attachment.attachmentId)}
+                  aria-label={`Delete ${attachment.fileName}`}
+                >
+                  <X className="h-4 w-4" />
                 </Button>
               )}
             </div>

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -38,6 +38,7 @@ export const API_ENDPOINTS = {
   notificationsUnreadCount: "/api/notifications/unread-count",
   notificationsReadAll: "/api/notifications/read-all",
   attachmentsRequestUpload: "/api/attachments/request-upload-url",
+  attachmentsRequestUploadV2: "/api/attachments/request-upload-url-v2",
   attachmentsAttach: "/api/attachments/attach",
   attachments: "/api/attachments",
   leaveApplications: "/api/attendance/leave",

--- a/apps/web/lib/types/attachment.ts
+++ b/apps/web/lib/types/attachment.ts
@@ -7,22 +7,24 @@ export interface AttachmentItem {
   uploadedAt: string;
 }
 
+export type AttachmentEntityType = "homework" | "notice";
+
 export interface RequestUploadUrlRequest {
   fileName: string;
   contentType: string;
   sizeBytes: number;
+  entityType: AttachmentEntityType;
 }
 
 export interface RequestUploadUrlResponse {
   uploadUrl: string;
-  storageKey: string;
   attachmentId: string;
 }
 
 export interface AttachFileRequest {
   attachmentId: string;
   entityId: string;
-  entityType: "homework" | "notice";
+  entityType: AttachmentEntityType;
 }
 
 export interface AttachFileResponse {
@@ -33,26 +35,97 @@ export interface DeleteAttachmentResponse {
   message: string;
 }
 
-export const ALLOWED_CONTENT_TYPES = [
+export const NOTICE_ALLOWED_CONTENT_TYPES = [
   "image/jpeg",
   "image/png",
   "image/webp",
   "application/pdf",
 ] as const;
 
+export const HOMEWORK_ALLOWED_CONTENT_TYPES = [
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+] as const;
+
 export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 export const MAX_ATTACHMENTS_PER_ENTITY = 5;
 
-export type AllowedContentType = (typeof ALLOWED_CONTENT_TYPES)[number];
+export const ATTACHMENT_ACCEPT = {
+  notice: {
+    "image/jpeg": [".jpg", ".jpeg"],
+    "image/png": [".png"],
+    "image/webp": [".webp"],
+    "application/pdf": [".pdf"],
+  },
+  homework: {
+    "application/pdf": [".pdf"],
+    "application/msword": [".doc"],
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+  },
+} as const;
+
+export type NoticeAllowedContentType =
+  (typeof NOTICE_ALLOWED_CONTENT_TYPES)[number];
+
+export type HomeworkAllowedContentType =
+  (typeof HOMEWORK_ALLOWED_CONTENT_TYPES)[number];
+
+export type AllowedContentType =
+  | NoticeAllowedContentType
+  | HomeworkAllowedContentType;
+
+export function getAllowedContentTypes(
+  entityType: AttachmentEntityType
+): readonly string[] {
+  return entityType === "homework"
+    ? HOMEWORK_ALLOWED_CONTENT_TYPES
+    : NOTICE_ALLOWED_CONTENT_TYPES;
+}
+
+export function getAcceptedFiles(
+  entityType: AttachmentEntityType
+): Record<string, readonly string[]> {
+  return { ...ATTACHMENT_ACCEPT[entityType] };
+}
 
 export function isAllowedContentType(
+  entityType: AttachmentEntityType,
   type: string
 ): type is AllowedContentType {
-  return (ALLOWED_CONTENT_TYPES as readonly string[]).includes(type);
+  return getAllowedContentTypes(entityType).includes(type);
 }
 
 export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function isPdfAttachment(contentType: string): boolean {
+  return contentType === "application/pdf";
+}
+
+export function isWordAttachment(contentType: string): boolean {
+  return (
+    contentType === "application/msword" ||
+    contentType ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  );
+}
+
+export function getAttachmentHelperText(
+  entityType: AttachmentEntityType
+): string {
+  return entityType === "homework"
+    ? "PDF, DOC, or DOCX — max 10MB each"
+    : "JPEG, PNG, WebP, or PDF — max 10MB each";
+}
+
+export function getAttachmentEmptyLabel(
+  entityType: AttachmentEntityType
+): string {
+  return entityType === "homework"
+    ? "Drag and drop homework files here, or browse"
+    : "Drag and drop notice files here, or browse";
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "next": "15.0.7",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-dropzone": "^15.0.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      react-dropzone:
+        specifier: ^15.0.0
+        version: 15.0.0(react@19.0.0)
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.6.1
@@ -1249,6 +1252,10 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1658,6 +1665,10 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2413,6 +2424,12 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-dropzone@15.0.0:
+    resolution: {integrity: sha512-lGjYV/EoqEjEWPnmiSvH4v5IoIAwQM2W4Z1C0Q/Pw2xD0eVzKPS359BQTUMum+1fa0kH2nrKjuavmTPOGhpLPg==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4154,6 +4171,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -4703,6 +4722,10 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   fill-range@7.1.1:
     dependencies:
@@ -5418,6 +5441,13 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-dropzone@15.0.0(react@19.0.0):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.0.0
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
Add v2 presigned upload flow with storage config, expanded homework content-types (PDF/DOC/DOCX), stricter homework/notice attachment authorization, and improved download headers. Update web uploader/list UI and add pnpm config to stabilize installs.

Made-with: Cursor