### PR TITLE
feat(security): add baseline HTTP security headers + CSP with nonce (…

### DIFF
--- a/apps/api/src/EduConnect.Api/Common/Middleware/SecurityHeadersMiddleware.cs
+++ b/apps/api/src/EduConnect.Api/Common/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,51 @@
+namespace EduConnect.Api.Common.Middleware;
+
+// Emits defence-in-depth response headers for every API response.
+// The API returns JSON only, so CSP is minimal ('none' + no framing).
+public class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        context.Response.OnStarting(static state =>
+        {
+            var ctx = (HttpContext)state;
+            var headers = ctx.Response.Headers;
+
+            static void SetIfMissing(IHeaderDictionary headers, string name, string value)
+            {
+                if (!headers.ContainsKey(name))
+                {
+                    headers[name] = value;
+                }
+            }
+
+            SetIfMissing(headers, "Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+            SetIfMissing(headers, "X-Content-Type-Options", "nosniff");
+            SetIfMissing(headers, "X-Frame-Options", "DENY");
+            SetIfMissing(headers, "Referrer-Policy", "strict-origin-when-cross-origin");
+            SetIfMissing(headers, "Permissions-Policy", "camera=(), microphone=(), geolocation=(), interest-cohort=()");
+            SetIfMissing(headers, "Cross-Origin-Resource-Policy", "same-origin");
+            SetIfMissing(headers, "Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; base-uri 'none'");
+
+            headers.Remove("Server");
+            headers.Remove("X-Powered-By");
+
+            return Task.CompletedTask;
+        }, context);
+
+        return _next(context);
+    }
+}
+
+public static class SecurityHeadersMiddlewareExtensions
+{
+    public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder builder)
+        => builder.UseMiddleware<SecurityHeadersMiddleware>();
+}

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -253,6 +253,8 @@ var app = builder.Build();
     }
 }
 
+app.UseSecurityHeaders();
+
 app.UseRouting();
 
 if (app.Environment.IsDevelopment())

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Manrope, Space_Grotesk } from "next/font/google";
+import { headers } from "next/headers";
 import { APP_NAME } from "@/lib/constants";
 import { validateEnv } from "@/lib/validate-env";
 import { AuthProvider } from "@/providers/auth-provider";
@@ -86,15 +87,17 @@ const themeScript = `
   })();
 `;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
-}): React.ReactElement {
+}): Promise<React.ReactElement> {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className={`${manrope.variable} ${spaceGrotesk.variable} antialiased`}>
         <ThemeProvider>

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,105 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+// Pull origins out of env at edge runtime. Empty values are filtered so CSP
+// stays strict in environments where a given dependency isn't configured.
+function originOrEmpty(url: string | undefined): string {
+  if (!url) return "";
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
+  }
+}
+
+function buildCsp(nonce: string): string {
+  const isProd = process.env.NODE_ENV === "production";
+
+  const apiOrigin = originOrEmpty(process.env.NEXT_PUBLIC_API_URL);
+  const mediaOrigin = originOrEmpty(process.env.NEXT_PUBLIC_MEDIA_BASE_URL);
+  const sentryEnabled = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN?.trim());
+
+  const connectSrc = [
+    "'self'",
+    apiOrigin,
+    sentryEnabled ? "https://*.sentry.io https://*.ingest.sentry.io" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const imgSrc = ["'self'", "data:", "blob:", mediaOrigin]
+    .filter(Boolean)
+    .join(" ");
+
+  // 'strict-dynamic' lets nonced root scripts transitively load Next.js bundles
+  // without needing each chunk hash listed. 'self' is ignored when strict-dynamic
+  // is present but keeping it satisfies non-nonce-aware scanners.
+  // Dev needs 'unsafe-eval' for React Refresh; prod stays strict.
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    isProd ? "" : "'unsafe-eval'",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const directives = [
+    `default-src 'self'`,
+    `script-src ${scriptSrc}`,
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src ${imgSrc}`,
+    `font-src 'self' data:`,
+    `connect-src ${connectSrc}`,
+    `worker-src 'self' blob:`,
+    `frame-ancestors 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `object-src 'none'`,
+    isProd ? `upgrade-insecure-requests` : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+
+  return directives;
+}
+
+function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const nonce = generateNonce();
+  const csp = buildCsp(nonce);
+
+  // Forward the nonce into the request so Server Components can read it via
+  // next/headers and attach it to inline <script> tags.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("content-security-policy", csp);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}
+
+// Exclude static assets and PWA files so we don't pay the middleware cost on
+// every icon/font fetch and don't accidentally CSP the service worker script.
+export const config = {
+  matcher: [
+    {
+      source:
+        "/((?!api|_next/static|_next/image|favicon.ico|manifest.json|sw.js|workbox-.*\\.js|icon-.*\\.png|apple-touch-icon\\.png).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,35 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
+// Response-invariant security headers applied to every route.
+// CSP is emitted from middleware.ts because it needs a per-request nonce.
+const securityHeaders = [
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+];
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   webpack: (config, { isServer }) => {
     // Suppress critical dependency warnings from OpenTelemetry/Sentry
     // These are caused by dynamic require() usage in Node.js instrumentation


### PR DESCRIPTION
…Phase 1)

Web (apps/web):
- next.config.ts now emits HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, COOP and CORP for every route.
- New middleware.ts generates a per-request nonce and emits a strict Content-Security-Policy. API and optional media origins are sourced from NEXT_PUBLIC_API_URL / NEXT_PUBLIC_MEDIA_BASE_URL; Sentry ingest hosts are allowed only when NEXT_PUBLIC_SENTRY_DSN is set. Dev adds 'unsafe-eval' for React Refresh; prod stays strict with 'strict-dynamic'.
- Root layout reads x-nonce from next/headers and applies it to the inline theme-boot script so CSP passes without 'unsafe-inline' on script-src.

API (apps/api):
- New SecurityHeadersMiddleware applies the baseline set plus a locked-down CSP (default-src 'none'; frame-ancestors 'none') suitable for a JSON API. Registered before routing so every response — including 404s and errors — carries the headers. Strips Server / X-Powered-By.

CORS policy was already allow-list via WithOrigins(corsOrigins); no change.

Rollback: revert this commit; no data or schema changes.