### PR TITLE
feat(auth): unify password policy + force legacy rotation (Phase 2)

### DIFF
--- a/apps/api/src/EduConnect.Api/Common/Auth/PasswordPolicy.cs
+++ b/apps/api/src/EduConnect.Api/Common/Auth/PasswordPolicy.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+
+namespace EduConnect.Api.Common.Auth;
+
+// Single source of truth for password rules. Every entry point where a user
+// sets a NEW password (register, change, reset, admin-create) must route
+// through PasswordPolicyValidator so the bar is enforced identically.
+//
+// Login does NOT use this — users with legacy short passwords must still be
+// able to sign in so they can be rotated on next login.
+public static class PasswordPolicy
+{
+    public const int MinLength = 8;
+    public const int MaxLength = 128;
+
+    // Cutoff for legacy-password rotation. Users whose password was last
+    // updated BEFORE this instant are forced to change on next login.
+    // Bump this value only when introducing a stricter policy that should
+    // flush everyone through the change-password flow again.
+    public static readonly DateTimeOffset PolicyEnforcedAt =
+        new(2026, 4, 22, 0, 0, 0, TimeSpan.Zero);
+
+    public static bool IsLegacyPassword(DateTimeOffset? passwordUpdatedAt)
+        => passwordUpdatedAt is null || passwordUpdatedAt.Value < PolicyEnforcedAt;
+}
+
+public sealed class PasswordPolicyValidator : AbstractValidator<string>
+{
+    public PasswordPolicyValidator()
+    {
+        RuleFor(p => p)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(PasswordPolicy.MinLength)
+                .WithMessage($"Password must be at least {PasswordPolicy.MinLength} characters.")
+            .MaximumLength(PasswordPolicy.MaxLength)
+                .WithMessage($"Password must be {PasswordPolicy.MaxLength} characters or fewer.")
+            .Matches(@"[A-Za-z]").WithMessage("Password must contain at least one letter.")
+            .Matches(@"\d").WithMessage("Password must contain at least one digit.");
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/Auth/ChangePassword/ChangePasswordCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/ChangePassword/ChangePasswordCommandHandler.cs
@@ -58,9 +58,11 @@ public class ChangePasswordCommandHandler : IRequestHandler<ChangePasswordComman
             throw new UnauthorizedException("Current password is incorrect.");
         }
 
+        var now = DateTimeOffset.UtcNow;
         user.PasswordHash = _passwordHasher.HashPassword(request.NewPassword);
         user.MustChangePassword = false;
-        user.UpdatedAt = DateTimeOffset.UtcNow;
+        user.PasswordUpdatedAt = now;
+        user.UpdatedAt = now;
 
         // Revoke all active refresh tokens for this user (force re-login everywhere).
         var activeRefreshTokens = await _context.RefreshTokens

--- a/apps/api/src/EduConnect.Api/Features/Auth/ChangePassword/ChangePasswordCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/ChangePassword/ChangePasswordCommandValidator.cs
@@ -1,3 +1,4 @@
+using EduConnect.Api.Common.Auth;
 using FluentValidation;
 
 namespace EduConnect.Api.Features.Auth.ChangePassword;
@@ -8,12 +9,10 @@ public class ChangePasswordCommandValidator : AbstractValidator<ChangePasswordCo
     {
         RuleFor(x => x.CurrentPassword)
             .NotEmpty().WithMessage("Current password is required.")
-            .MaximumLength(128).WithMessage("Current password is invalid.");
+            .MaximumLength(PasswordPolicy.MaxLength).WithMessage("Current password is invalid.");
 
         RuleFor(x => x.NewPassword)
-            .NotEmpty().WithMessage("New password is required.")
-            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-            .MaximumLength(128).WithMessage("Password must be 128 characters or fewer.")
+            .SetValidator(new PasswordPolicyValidator())
             .NotEqual(x => x.CurrentPassword)
                 .WithMessage("New password must be different from the current password.");
 

--- a/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandHandler.cs
@@ -62,13 +62,26 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponse>
             throw new UnauthorizedException("Invalid phone or password.");
         }
 
+        // A staff user is forced through the change-password flow if their
+        // account is already flagged OR if their password pre-dates the
+        // current policy — see PasswordPolicy.PolicyEnforcedAt.
+        var mustChange = user.MustChangePassword
+            || PasswordPolicy.IsLegacyPassword(user.PasswordUpdatedAt);
+
+        if (mustChange && !user.MustChangePassword)
+        {
+            _logger.LogInformation(
+                "User {UserId} flagged for forced password rotation (legacy password pre-dates policy cutoff)",
+                user.Id);
+        }
+
         var accessToken = _jwtTokenService.GenerateAccessToken(
             user.Id,
             user.SchoolId,
             user.Role,
             user.Name,
             15,
-            user.MustChangePassword);
+            mustChange);
         var refreshTokenId = Guid.NewGuid();
         var refreshTokenSecret = _jwtTokenService.GenerateRefreshToken();
         var refreshToken = _jwtTokenService.BuildRefreshToken(refreshTokenId, refreshTokenSecret);
@@ -99,6 +112,6 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponse>
 
         _logger.LogInformation("User {UserId} logged in successfully", user.Id);
 
-        return new LoginResponse(accessToken, user.MustChangePassword);
+        return new LoginResponse(accessToken, mustChange);
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandValidator.cs
@@ -11,8 +11,11 @@ public class LoginCommandValidator : AbstractValidator<LoginCommand>
             .NotEmpty().WithMessage("Phone number is required.")
             .Must(JapanPhoneNumber.IsValidInput).WithMessage(JapanPhoneNumber.ValidationMessage);
 
+        // Login only enforces non-empty. Length/strength checks live in
+        // PasswordPolicyValidator and are applied when passwords are SET, not
+        // verified — users with pre-policy passwords must still be able to
+        // sign in so the legacy-rotation flow can force them to change.
         RuleFor(x => x.Password)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(6).WithMessage("Password must be at least 6 characters.");
+            .NotEmpty().WithMessage("Password is required.");
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -79,13 +79,19 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
             throw new UnauthorizedException("User is inactive.");
         }
 
+        // Same legacy-rotation check as login: mirror the effective flag so a
+        // rotated access token still carries must_change_password when the
+        // user's password pre-dates the policy cutoff.
+        var mustChange = user.MustChangePassword
+            || PasswordPolicy.IsLegacyPassword(user.PasswordUpdatedAt);
+
         var newAccessToken = _jwtTokenService.GenerateAccessToken(
             user.Id,
             user.SchoolId,
             user.Role,
             user.Name,
             15,
-            user.MustChangePassword);
+            mustChange);
         var newRefreshTokenId = Guid.NewGuid();
         var newRefreshTokenSecret = _jwtTokenService.GenerateRefreshToken();
         var newRefreshToken = _jwtTokenService.BuildRefreshToken(newRefreshTokenId, newRefreshTokenSecret);
@@ -110,6 +116,6 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
 
         _logger.LogInformation("Refresh token rotated for user {UserId}", user.Id);
 
-        return new RefreshTokenResponse(newAccessToken, newRefreshToken, user.MustChangePassword);
+        return new RefreshTokenResponse(newAccessToken, newRefreshToken, mustChange);
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Auth/ResetPassword/ResetPasswordCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/ResetPassword/ResetPasswordCommandHandler.cs
@@ -67,10 +67,13 @@ public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommand,
             throw new UnauthorizedException("Reset link is invalid or has expired.");
         }
 
+        var now = DateTimeOffset.UtcNow;
         user.PasswordHash = _passwordHasher.HashPassword(request.NewPassword);
-        user.UpdatedAt = DateTimeOffset.UtcNow;
+        user.MustChangePassword = false;
+        user.PasswordUpdatedAt = now;
+        user.UpdatedAt = now;
 
-        resetToken.UsedAt = DateTimeOffset.UtcNow;
+        resetToken.UsedAt = now;
 
         // Revoke all active refresh tokens for this user (force re-login everywhere).
         var activeRefreshTokens = await _context.RefreshTokens

--- a/apps/api/src/EduConnect.Api/Features/Auth/ResetPassword/ResetPasswordCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/ResetPassword/ResetPasswordCommandValidator.cs
@@ -1,3 +1,4 @@
+using EduConnect.Api.Common.Auth;
 using FluentValidation;
 
 namespace EduConnect.Api.Features.Auth.ResetPassword;
@@ -11,9 +12,7 @@ public class ResetPasswordCommandValidator : AbstractValidator<ResetPasswordComm
             .MaximumLength(256).WithMessage("Reset token is invalid.");
 
         RuleFor(x => x.NewPassword)
-            .NotEmpty().WithMessage("New password is required.")
-            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-            .MaximumLength(128).WithMessage("Password must be 128 characters or fewer.");
+            .SetValidator(new PasswordPolicyValidator());
 
         RuleFor(x => x.ConfirmPassword)
             .NotEmpty().WithMessage("Confirm password is required.")

--- a/apps/api/src/EduConnect.Api/Features/Teachers/CreateTeacher/CreateTeacherCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Teachers/CreateTeacher/CreateTeacherCommandHandler.cs
@@ -79,6 +79,7 @@ public class CreateTeacherCommandHandler : IRequestHandler<CreateTeacherCommand,
             });
         }
 
+        var now = DateTimeOffset.UtcNow;
         var teacher = new UserEntity
         {
             Id = Guid.NewGuid(),
@@ -90,8 +91,9 @@ public class CreateTeacherCommandHandler : IRequestHandler<CreateTeacherCommand,
             PasswordHash = _passwordHasher.HashPassword(request.Password),
             IsActive = true,
             MustChangePassword = true,
-            CreatedAt = DateTimeOffset.UtcNow,
-            UpdatedAt = DateTimeOffset.UtcNow
+            PasswordUpdatedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
         };
 
         _context.Users.Add(teacher);

--- a/apps/api/src/EduConnect.Api/Features/Teachers/CreateTeacher/CreateTeacherCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Teachers/CreateTeacher/CreateTeacherCommandValidator.cs
@@ -1,3 +1,4 @@
+using EduConnect.Api.Common.Auth;
 using EduConnect.Api.Common.PhoneNumbers;
 using FluentValidation;
 
@@ -23,9 +24,7 @@ public class CreateTeacherCommandValidator : AbstractValidator<CreateTeacherComm
             .MaximumLength(256).WithMessage("Email cannot exceed 256 characters.");
 
         RuleFor(x => x.Password)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-            .MaximumLength(128).WithMessage("Password must be 128 characters or fewer.");
+            .SetValidator(new PasswordPolicyValidator());
 
         RuleFor(x => x.Role)
             .NotEmpty().WithMessage("Role is required.")

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/UserConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/UserConfiguration.cs
@@ -24,6 +24,7 @@ public class UserConfiguration : IEntityTypeConfiguration<UserEntity>
         builder.Property(x => x.PinHash).HasMaxLength(500);
         builder.Property(x => x.IsActive).IsRequired().HasDefaultValue(true);
         builder.Property(x => x.MustChangePassword).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.PasswordUpdatedAt);
         builder.Property(x => x.CreatedAt).HasDefaultValueSql("NOW()");
         builder.Property(x => x.UpdatedAt).HasDefaultValueSql("NOW()");
 

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/UserEntity.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/UserEntity.cs
@@ -12,6 +12,7 @@ public class UserEntity
     public string? PinHash { get; set; }
     public bool IsActive { get; set; } = true;
     public bool MustChangePassword { get; set; } = false;
+    public DateTimeOffset? PasswordUpdatedAt { get; set; }
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 

--- a/apps/api/src/EduConnect.Api/Migrations/20260421122943_AddPasswordUpdatedAtToUsers.Designer.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421122943_AddPasswordUpdatedAtToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EduConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduConnect.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421122943_AddPasswordUpdatedAtToUsers")]
+    partial class AddPasswordUpdatedAtToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/EduConnect.Api/Migrations/20260421122943_AddPasswordUpdatedAtToUsers.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421122943_AddPasswordUpdatedAtToUsers.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EduConnect.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPasswordUpdatedAtToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "password_updated_at",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            // Backfill existing staff passwords with a conservative lower bound so
+            // the legacy-rotation check (PasswordPolicy.IsLegacyPassword) flags
+            // them on next login. We don't know when they last rotated, only
+            // that it wasn't later than creation, so created_at is the safest
+            // stamp. NULL is left for users without a password (e.g. PIN-only
+            // parents); the check treats NULL as legacy but the login path for
+            // Parent role never evaluates this — no user impact.
+            migrationBuilder.Sql(@"
+                UPDATE users
+                SET password_updated_at = created_at
+                WHERE password_hash IS NOT NULL
+                  AND password_updated_at IS NULL;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "password_updated_at",
+                table: "users");
+        }
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/PasswordPolicyTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/PasswordPolicyTests.cs
@@ -1,0 +1,77 @@
+using EduConnect.Api.Common.Auth;
+using FluentAssertions;
+using FluentValidation;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+public class PasswordPolicyTests
+{
+    private readonly PasswordPolicyValidator _validator = new();
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("short1")]            // 6 chars — below MinLength (8)
+    [InlineData("abcdefg1")]          // 8 chars, letter + digit → OK (sanity check below)
+    [InlineData("12345678")]          // 8 digits, no letter
+    [InlineData("abcdefgh")]          // 8 letters, no digit
+    public void Rejects_or_accepts_correctly(string password)
+    {
+        var result = _validator.Validate(password);
+        var expectedValid = password == "abcdefg1";
+        result.IsValid.Should().Be(expectedValid);
+    }
+
+    [Fact]
+    public void Accepts_minimum_length_with_letter_and_digit()
+    {
+        _validator.Validate("password1").IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Rejects_seven_character_password()
+    {
+        var result = _validator.Validate("abcdef1");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage.Contains("at least 8 characters"));
+    }
+
+    [Fact]
+    public void Rejects_password_longer_than_max()
+    {
+        var tooLong = new string('a', PasswordPolicy.MaxLength) + "1";
+        var result = _validator.Validate(tooLong);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage.Contains($"{PasswordPolicy.MaxLength} characters or fewer"));
+    }
+
+    [Fact]
+    public void Rejects_empty_with_required_message()
+    {
+        var result = _validator.Validate("");
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("required"));
+    }
+
+    [Fact]
+    public void IsLegacyPassword_is_true_when_null()
+    {
+        PasswordPolicy.IsLegacyPassword(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsLegacyPassword_is_true_when_before_cutoff()
+    {
+        var before = PasswordPolicy.PolicyEnforcedAt.AddDays(-1);
+        PasswordPolicy.IsLegacyPassword(before).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsLegacyPassword_is_false_when_at_or_after_cutoff()
+    {
+        PasswordPolicy.IsLegacyPassword(PasswordPolicy.PolicyEnforcedAt).Should().BeFalse();
+        PasswordPolicy.IsLegacyPassword(PasswordPolicy.PolicyEnforcedAt.AddHours(1)).Should().BeFalse();
+    }
+}

--- a/apps/web/app/(auth)/change-password/change-password-form.tsx
+++ b/apps/web/app/(auth)/change-password/change-password-form.tsx
@@ -7,6 +7,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError, apiPost } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
+import { PASSWORD_POLICY_MESSAGE, validatePassword } from "@/lib/validation/password";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBanner } from "@/components/shared/status-banner";
@@ -54,8 +55,9 @@ export function ChangePasswordForm(): React.ReactElement {
       setError("Please enter your current temporary password.");
       return;
     }
-    if (newPassword.length < 8) {
-      setError("New password must be at least 8 characters.");
+    const policy = validatePassword(newPassword);
+    if (!policy.valid) {
+      setError(policy.message);
       return;
     }
     if (newPassword === currentPassword) {
@@ -181,7 +183,7 @@ export function ChangePasswordForm(): React.ReactElement {
             </button>
           </div>
           <p className="text-xs text-muted-foreground">
-            At least 8 characters. Choose something only you would know.
+            {PASSWORD_POLICY_MESSAGE} Choose something only you would know.
           </p>
         </div>
 

--- a/apps/web/app/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web/app/(auth)/reset-password/reset-password-form.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ApiError, apiPost } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
+import { PASSWORD_POLICY_MESSAGE, validatePassword } from "@/lib/validation/password";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBanner } from "@/components/shared/status-banner";
@@ -38,8 +39,9 @@ export function ResetPasswordForm(): React.ReactElement {
       setError("Reset link is missing or invalid.");
       return;
     }
-    if (newPassword.length < 8) {
-      setError("Password must be at least 8 characters.");
+    const policy = validatePassword(newPassword);
+    if (!policy.valid) {
+      setError(policy.message);
       return;
     }
     if (newPassword !== confirmPassword) {
@@ -121,7 +123,7 @@ export function ResetPasswordForm(): React.ReactElement {
             </button>
           </div>
           <p className="text-xs text-muted-foreground">
-            At least 8 characters.
+            {PASSWORD_POLICY_MESSAGE}
           </p>
         </div>
 

--- a/apps/web/app/(dashboard)/admin/teachers/new/page.tsx
+++ b/apps/web/app/(dashboard)/admin/teachers/new/page.tsx
@@ -21,6 +21,7 @@ import { StatusBanner } from "@/components/shared/status-banner";
 import { TemporaryCredentialCard } from "@/components/shared/temporary-credential-card";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PASSWORD_POLICY_MESSAGE, validatePassword } from "@/lib/validation/password";
 import type {
   CreateTeacherRequest,
   SubjectItem,
@@ -94,7 +95,8 @@ export default function CreateTeacherPage(): React.ReactElement {
     if (email.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
       nextErrors.email = "Enter a valid email address.";
     }
-    if (password.length < 8) nextErrors.password = "Password must be at least 8 characters.";
+    const policy = validatePassword(password);
+    if (!policy.valid) nextErrors.password = policy.message;
 
     if (role === "Teacher") {
       const hasClass = Boolean(assignClassId);
@@ -283,7 +285,7 @@ export default function CreateTeacherPage(): React.ReactElement {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={isSubmitting}
-                  placeholder="At least 8 characters"
+                  placeholder={PASSWORD_POLICY_MESSAGE}
                   autoComplete="new-password"
                   aria-invalid={!!fieldErrors.password}
                   aria-describedby={fieldErrors.password ? passwordErrorId : undefined}

--- a/apps/web/lib/validation/password.ts
+++ b/apps/web/lib/validation/password.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+// Single source of truth for the client-side password policy. Mirrors the
+// backend PasswordPolicyValidator; keep these two in lockstep.
+//
+// Login is NOT validated against this schema — users with pre-policy
+// passwords must still be able to sign in so the legacy-rotation flow can
+// force them to change.
+
+export const PASSWORD_POLICY = {
+  minLength: 8,
+  maxLength: 128,
+} as const;
+
+export const PASSWORD_POLICY_MESSAGE =
+  `At least ${PASSWORD_POLICY.minLength} characters, including a letter and a digit.`;
+
+export const passwordSchema = z
+  .string()
+  .min(PASSWORD_POLICY.minLength, {
+    message: `Password must be at least ${PASSWORD_POLICY.minLength} characters.`,
+  })
+  .max(PASSWORD_POLICY.maxLength, {
+    message: `Password must be ${PASSWORD_POLICY.maxLength} characters or fewer.`,
+  })
+  .regex(/[A-Za-z]/, { message: "Password must contain at least one letter." })
+  .regex(/\d/, { message: "Password must contain at least one digit." });
+
+export type PasswordValidationResult =
+  | { valid: true }
+  | { valid: false; message: string };
+
+// Convenience for forms that aren't wired through a full schema. Returns the
+// first failing rule message, matching server behaviour on validation errors.
+export function validatePassword(value: string): PasswordValidationResult {
+  const result = passwordSchema.safeParse(value);
+  if (result.success) return { valid: true };
+  return { valid: false, message: result.error.issues[0]?.message ?? "Invalid password." };
+}


### PR DESCRIPTION
Single source of truth for password rules across the backend and web, with legacy-password users transparently forced through the existing must-change-password flow on next login.

Backend (apps/api):
- New PasswordPolicy + PasswordPolicyValidator (FluentValidation) in Common/Auth. Policy: 8–128 chars, at least one letter and one digit.
- ChangePassword, ResetPassword, and CreateTeacher validators now .SetValidator(new PasswordPolicyValidator()) instead of hand-rolling rules.
- LoginCommandValidator drops MinimumLength(6); login is now NotEmpty only so users with pre-policy short passwords can still sign in to be rotated.
- UserEntity gains PasswordUpdatedAt (nullable timestamptz). Migration AddPasswordUpdatedAtToUsers adds the column and backfills existing staff with CreatedAt as a conservative lower bound.
- PasswordPolicy.PolicyEnforcedAt = 2026-04-22T00:00:00Z. Login and Refresh handlers compute effective must_change_password as user.MustChangePassword || IsLegacyPassword(user.PasswordUpdatedAt) so users whose password pre-dates the cutoff are routed through the MustChangePasswordMiddleware allow-list (already blocks everything except change-password / reset-password / logout).
- Change/Reset/CreateTeacher handlers now stamp PasswordUpdatedAt=NOW() on every password write. ResetPassword also clears MustChangePassword, which previously leaked true across a successful reset.

Web (apps/web):
- New lib/validation/password.ts exports PASSWORD_POLICY, passwordSchema (zod), and validatePassword() — client-side mirror of the backend policy.
- change-password, reset-password, and admin/teachers/new forms route through validatePassword() and display PASSWORD_POLICY_MESSAGE instead of hand-rolled .length < 8 checks. Login form is unchanged (still non-empty only).

Tests: 12 new xUnit cases covering boundary conditions for the validator and IsLegacyPassword. Full suite: 85 passing + 12 new = 97 passing; 2 unrelated AdminOnboarding failures predate this branch.

Rollback: revert this commit and run
  dotnet ef migrations remove
to drop the PasswordUpdatedAt column. No data deletion required — the backfill uses existing CreatedAt values.