### PR TITLE
feat(db): enforce tenant isolation at PostgreSQL layer via RLS (Phase 4)

### DIFF
--- a/apps/api/docs/row-level-security.md
+++ b/apps/api/docs/row-level-security.md
@@ -1,0 +1,98 @@
+# Row-level security (Phase 4)
+
+Every tenanted table in the EduConnect database carries a PostgreSQL
+row-level-security policy of the form:
+
+```sql
+USING (
+  current_app_school_id() IS NULL
+  OR school_id = current_app_school_id()
+)
+WITH CHECK (
+  current_app_school_id() IS NULL
+  OR school_id = current_app_school_id()
+)
+```
+
+`current_app_school_id()` is a `STABLE SQL` function that reads the session
+GUC `app.current_school_id`. When the GUC is unset or empty the function
+returns `NULL`, which the policy treats as a bypass — matching the pre-Phase 4
+EF global-query-filter semantics (unauthenticated requests can see
+everything, tenant scoping applies only when a tenant is known). Every
+authenticated request path sets the GUC via `TenantConnectionInterceptor`.
+
+## Enforcing RLS in a deployed environment
+
+The migration enables `ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`
+on every tenanted table. `FORCE` subjects the table owner to policies too —
+**but** roles with the `BYPASSRLS` attribute (and all superusers) still
+bypass RLS at the PostgreSQL level. That is a Postgres invariant, not
+something the application can override.
+
+For RLS to actually isolate tenants in production you must connect the
+application to a runtime role that has **neither** `BYPASSRLS` nor
+`SUPERUSER`:
+
+```sql
+-- Run once as a superuser on the target database.
+CREATE ROLE app_runtime LOGIN PASSWORD :'runtime_password' NOSUPERUSER NOBYPASSRLS;
+GRANT CONNECT ON DATABASE educonnect TO app_runtime;
+GRANT USAGE ON SCHEMA public TO app_runtime;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_runtime;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_runtime;
+-- Future tables created by migrations inherit these grants:
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_runtime;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO app_runtime;
+```
+
+Then point `DATABASE_URL` at the `app_runtime` user for the running API
+process. Keep migrations running as the owner/superuser so DDL continues
+to succeed.
+
+## Verifying RLS is effective
+
+Integration tests in `TenantIsolationRlsTests.cs` validate the policies
+against a real PostgreSQL. They auto-skip when:
+
+- `EDUCONNECT_TEST_DB_URL` is unset, **or**
+- the connection role has `BYPASSRLS` / `SUPERUSER` (RLS cannot be
+  enforced in that configuration).
+
+Run locally once you have a restricted role in place:
+
+```bash
+EDUCONNECT_TEST_DB_URL="Host=...;Port=...;Database=educonnect;Username=app_runtime;Password=..." \
+  dotnet test --filter FullyQualifiedName~TenantIsolationRls
+```
+
+A green run proves all three invariants:
+
+1. `SELECT` with no `WHERE school_id` returns only the current tenant's rows.
+2. `UPDATE` by primary key against a foreign tenant's row affects 0 rows.
+3. `INSERT` with a foreign `school_id` is rejected with `SQLSTATE 42501`.
+
+## Anonymous / cross-tenant endpoints
+
+Today's anonymous request paths (login, login-parent, refresh, forgot/reset
+password) legitimately need to look users up by phone without a known
+tenant. The `TenantConnectionInterceptor` clears `app.current_school_id`
+to the empty string on those connections, which makes
+`current_app_school_id()` return `NULL` and therefore makes the RLS
+policy admit every row — the same behaviour as the existing EF global
+query filter's `!IsAuthenticated` branch.
+
+This is safe because these endpoints are a hand-curated surface, each of
+which already performs its own narrow lookup (`WHERE phone = @p`,
+`WHERE token_hash = @h`, …). If an endpoint ever legitimately needs to
+serve cross-tenant **authenticated** reads (e.g. a super-admin dashboard),
+it should open its queries under a connection where the GUC has been
+explicitly cleared, gated behind an explicit `[RequireSuperAdmin]`
+authorisation check. Never the default path.
+
+## App-level filtering remains
+
+`AppDbContext.OnModelCreating` still applies per-entity global query
+filters on `SchoolId`. RLS is defence in depth — the two layers must
+agree. Do not remove the EF filters as part of Phase 4 or later.

--- a/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/Login/LoginCommandHandler.cs
@@ -79,6 +79,7 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponse>
         {
             Id = refreshTokenId,
             UserId = user.Id,
+            SchoolId = user.SchoolId,
             TokenHash = refreshTokenHash,
             ExpiresAt = refreshTokenExpiresAt,
             IsRevoked = false,

--- a/apps/api/src/EduConnect.Api/Features/Auth/LoginParent/LoginParentCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/LoginParent/LoginParentCommandHandler.cs
@@ -81,6 +81,7 @@ public class LoginParentCommandHandler : IRequestHandler<LoginParentCommand, Log
         {
             Id = refreshTokenId,
             UserId = user.Id,
+            SchoolId = user.SchoolId,
             TokenHash = refreshTokenHash,
             ExpiresAt = refreshTokenExpiresAt,
             IsRevoked = false,

--- a/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -133,6 +133,7 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
         {
             Id = newRefreshTokenId,
             UserId = user.Id,
+            SchoolId = user.SchoolId,
             TokenHash = newRefreshTokenHash,
             ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
             IsRevoked = false,

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/AppDbContext.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/AppDbContext.cs
@@ -77,7 +77,7 @@ public class AppDbContext : DbContext
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated || entity.SchoolId == _currentUserService.SchoolId);
         modelBuilder.Entity<RefreshTokenEntity>()
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated ||
-                                      (entity.User != null && entity.User.SchoolId == _currentUserService.SchoolId));
+                                      entity.SchoolId == _currentUserService.SchoolId);
         modelBuilder.Entity<AuthResetTokenEntity>()
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated ||
                                       entity.SchoolId == _currentUserService.SchoolId);

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/RefreshTokenConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/RefreshTokenConfiguration.cs
@@ -13,11 +13,13 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshTokenEn
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.SchoolId).IsRequired();
         builder.Property(x => x.TokenHash).IsRequired().HasMaxLength(500);
         builder.Property(x => x.IsRevoked).IsRequired().HasDefaultValue(false);
         builder.Property(x => x.CreatedAt).HasDefaultValueSql("NOW()");
 
         builder.HasIndex(x => x.UserId);
+        builder.HasIndex(x => x.SchoolId);
         builder.HasIndex(x => new { x.UserId, x.IsRevoked })
             .HasFilter("is_revoked = false");
 

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/RefreshTokenEntity.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/RefreshTokenEntity.cs
@@ -4,6 +4,7 @@ public class RefreshTokenEntity
 {
     public Guid Id { get; set; }
     public Guid UserId { get; set; }
+    public Guid SchoolId { get; set; }
     public string TokenHash { get; set; } = string.Empty;
     public DateTimeOffset ExpiresAt { get; set; }
     public bool IsRevoked { get; set; } = false;

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Interceptors/TenantConnectionInterceptor.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Interceptors/TenantConnectionInterceptor.cs
@@ -1,0 +1,78 @@
+using System.Data.Common;
+using EduConnect.Api.Common.Auth;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EduConnect.Api.Infrastructure.Database.Interceptors;
+
+/// <summary>
+/// On every physical connection open, stamps <c>app.current_school_id</c> on
+/// the PostgreSQL session so the per-table RLS policy
+/// <c>current_app_school_id() IS NULL OR school_id = current_app_school_id()</c>
+/// evaluates to the caller's tenant only.
+///
+/// When no tenant is known (anonymous login/refresh paths, startup seeding),
+/// the GUC is explicitly cleared to empty so the policy function returns NULL
+/// and the row is visible — matching the existing EF global query filter
+/// semantics where <c>!IsAuthenticated</c> short-circuits the tenant check.
+/// Anonymous code paths are a hand-curated surface; app-level controls
+/// continue to gate which tables they touch.
+/// </summary>
+public sealed class TenantConnectionInterceptor : DbConnectionInterceptor
+{
+    private readonly CurrentUserService _currentUserService;
+
+    public TenantConnectionInterceptor(CurrentUserService currentUserService)
+    {
+        _currentUserService = currentUserService;
+    }
+
+    public override async Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        await ApplyTenantGucAsync(connection, cancellationToken);
+        await base.ConnectionOpenedAsync(connection, eventData, cancellationToken);
+    }
+
+    public override void ConnectionOpened(
+        DbConnection connection,
+        ConnectionEndEventData eventData)
+    {
+        ApplyTenantGuc(connection);
+        base.ConnectionOpened(connection, eventData);
+    }
+
+    private async Task ApplyTenantGucAsync(DbConnection connection, CancellationToken ct)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT set_config('app.current_school_id', @p0, false)";
+        var parameter = cmd.CreateParameter();
+        parameter.ParameterName = "@p0";
+        parameter.Value = ResolveTenantValue();
+        cmd.Parameters.Add(parameter);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private void ApplyTenantGuc(DbConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT set_config('app.current_school_id', @p0, false)";
+        var parameter = cmd.CreateParameter();
+        parameter.ParameterName = "@p0";
+        parameter.Value = ResolveTenantValue();
+        cmd.Parameters.Add(parameter);
+        cmd.ExecuteNonQuery();
+    }
+
+    private string ResolveTenantValue()
+    {
+        if (_currentUserService.IsAuthenticated && _currentUserService.SchoolId != Guid.Empty)
+        {
+            return _currentUserService.SchoolId.ToString();
+        }
+        // Empty string → current_app_school_id() returns NULL → policy bypasses
+        // tenant check. Only reachable on anonymous/bootstrap paths.
+        return string.Empty;
+    }
+}

--- a/apps/api/src/EduConnect.Api/Migrations/20260421142201_EnableRowLevelSecurity.Designer.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421142201_EnableRowLevelSecurity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EduConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduConnect.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421142201_EnableRowLevelSecurity")]
+    partial class EnableRowLevelSecurity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/EduConnect.Api/Migrations/20260421142201_EnableRowLevelSecurity.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421142201_EnableRowLevelSecurity.cs
@@ -1,0 +1,121 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EduConnect.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnableRowLevelSecurity : Migration
+    {
+        // Every row-owning table in the schema has a school_id column after
+        // this migration runs. refresh_tokens previously tracked tenancy via
+        // its users FK join; that column is added and backfilled here so RLS
+        // policies can read school_id directly like every other table.
+        private static readonly string[] TenantedTablesWithSchoolIdColumn =
+        {
+            "users",
+            "classes",
+            "students",
+            "teacher_class_assignments",
+            "parent_student_links",
+            "attendance_records",
+            "homework",
+            "notices",
+            "notice_target_classes",
+            "subjects",
+            "notifications",
+            "attachments",
+            "leave_applications",
+            "refresh_tokens",
+            "auth_reset_tokens",
+            "user_push_subscriptions",
+            "exams",
+            "exam_subjects",
+            "exam_results",
+        };
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. refresh_tokens gains its own school_id column, backfilled
+            // from the user FK before we tighten NOT NULL.
+            migrationBuilder.Sql("ALTER TABLE refresh_tokens ADD COLUMN school_id uuid NULL;");
+            migrationBuilder.Sql(@"
+                UPDATE refresh_tokens rt
+                SET school_id = u.school_id
+                FROM users u
+                WHERE u.id = rt.user_id AND rt.school_id IS NULL;
+            ");
+            migrationBuilder.Sql("ALTER TABLE refresh_tokens ALTER COLUMN school_id SET NOT NULL;");
+            migrationBuilder.Sql(@"
+                ALTER TABLE refresh_tokens
+                ADD CONSTRAINT fk_refresh_tokens_schools_school_id
+                FOREIGN KEY (school_id) REFERENCES schools(id) ON DELETE CASCADE;
+            ");
+            migrationBuilder.CreateIndex(
+                name: "ix_refresh_tokens_school_id",
+                table: "refresh_tokens",
+                column: "school_id");
+
+            // 2. Tenant-lookup helper used by every policy. Returns NULL when
+            // the app.current_school_id GUC is unset or empty so anonymous
+            // paths (login, refresh, seeding) behave identically to the EF
+            // global query filter's "!IsAuthenticated" bypass.
+            migrationBuilder.Sql(@"
+                CREATE OR REPLACE FUNCTION current_app_school_id() RETURNS uuid
+                LANGUAGE SQL STABLE AS $$
+                  SELECT NULLIF(current_setting('app.current_school_id', true), '')::uuid;
+                $$;
+            ");
+
+            // 3. schools is the tenancy root. The policy compares id, not
+            // school_id. ENABLE + FORCE so the table owner is subject to RLS
+            // without needing a dedicated app_runtime role (Phase 4 deploy
+            // notes describe that follow-up).
+            migrationBuilder.Sql("ALTER TABLE schools ENABLE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE schools FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql(@"
+                CREATE POLICY tenant_isolation ON schools
+                USING (current_app_school_id() IS NULL OR id = current_app_school_id())
+                WITH CHECK (current_app_school_id() IS NULL OR id = current_app_school_id());
+            ");
+
+            // 4. Uniform policy for every table with a school_id column.
+            foreach (var table in TenantedTablesWithSchoolIdColumn)
+            {
+                migrationBuilder.Sql($"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;");
+                migrationBuilder.Sql($"ALTER TABLE {table} FORCE ROW LEVEL SECURITY;");
+                migrationBuilder.Sql($@"
+                    CREATE POLICY tenant_isolation ON {table}
+                    USING (current_app_school_id() IS NULL OR school_id = current_app_school_id())
+                    WITH CHECK (current_app_school_id() IS NULL OR school_id = current_app_school_id());
+                ");
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            foreach (var table in TenantedTablesWithSchoolIdColumn)
+            {
+                migrationBuilder.Sql($"DROP POLICY IF EXISTS tenant_isolation ON {table};");
+                migrationBuilder.Sql($"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY;");
+                migrationBuilder.Sql($"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY;");
+            }
+
+            migrationBuilder.Sql("DROP POLICY IF EXISTS tenant_isolation ON schools;");
+            migrationBuilder.Sql("ALTER TABLE schools NO FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE schools DISABLE ROW LEVEL SECURITY;");
+
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS current_app_school_id();");
+
+            migrationBuilder.DropIndex(
+                name: "ix_refresh_tokens_school_id",
+                table: "refresh_tokens");
+            migrationBuilder.Sql("ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_refresh_tokens_schools_school_id;");
+            migrationBuilder.DropColumn(
+                name: "school_id",
+                table: "refresh_tokens");
+        }
+    }
+}

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -61,11 +61,14 @@ var jwtAudience = builder.Configuration["JWT_AUDIENCE"];
 var databaseConnectionString = DatabaseConnectionStringResolver.Resolve(databaseUrl);
 
 builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Database.Interceptors.AuditableEntityInterceptor>();
+builder.Services.AddScoped<EduConnect.Api.Infrastructure.Database.Interceptors.TenantConnectionInterceptor>();
 
 builder.Services.AddDbContext<AppDbContext>((sp, options) =>
 {
     options.UseNpgsql(databaseConnectionString);
-    options.AddInterceptors(sp.GetRequiredService<EduConnect.Api.Infrastructure.Database.Interceptors.AuditableEntityInterceptor>());
+    options.AddInterceptors(
+        sp.GetRequiredService<EduConnect.Api.Infrastructure.Database.Interceptors.AuditableEntityInterceptor>(),
+        sp.GetRequiredService<EduConnect.Api.Infrastructure.Database.Interceptors.TenantConnectionInterceptor>());
 });
 
 builder.Services.AddMediatR(cfg =>

--- a/apps/api/tests/EduConnect.Api.Tests/EduConnect.Api.Tests.csproj
+++ b/apps/api/tests/EduConnect.Api.Tests/EduConnect.Api.Tests.csproj
@@ -17,6 +17,10 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <!-- SkippableFact lets RLS tests skip at runtime when the connection
+         role bypasses RLS (BYPASSRLS/SUPERUSER), which can't be detected
+         in the [Fact] attribute constructor. -->
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/api/tests/EduConnect.Api.Tests/TenantIsolationRlsTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/TenantIsolationRlsTests.cs
@@ -1,0 +1,224 @@
+using FluentAssertions;
+using Npgsql;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Black-box validation of the Phase 4 row-level security policies. Connects
+/// to a real PostgreSQL instance via EDUCONNECT_TEST_DB_URL (see docker-compose
+/// or a local test DB — migrations must already be applied) and verifies that
+/// <c>app.current_school_id</c> confines every query to the matching tenant
+/// without changing the caller's WHERE clause.
+///
+/// Requirements for green:
+///   1. EDUCONNECT_TEST_DB_URL is set.
+///   2. The migrations in this branch have been applied to that database.
+///   3. The connection role DOES NOT have BYPASSRLS or SUPERUSER — both
+///      skip RLS enforcement at the PG level regardless of FORCE. Tests
+///      auto-skip (not fail) when this isn't the case, so running against
+///      the default superuser role produces a clear Skip reason rather
+///      than a misleading assertion failure.
+///
+/// Uses the subjects table because it's the simplest tenanted shape:
+/// (id, school_id, name, created_at) with a unique (school_id, name) index.
+/// </summary>
+public class TenantIsolationRlsTests
+{
+    private const string NamePrefix = "rls-test";
+
+    private static string? ConnectionString =>
+        Environment.GetEnvironmentVariable("EDUCONNECT_TEST_DB_URL");
+
+    [SkippableFact]
+    public async Task Tenant_context_restricts_SELECT_to_matching_school()
+    {
+        await EnsureEnvironmentAsync();
+
+        var (schoolA, schoolB, _, _) = await SeedTwoSchoolsAsync();
+        try
+        {
+            await using var conn = await OpenConnectionAsync();
+            await SetTenantAsync(conn, schoolA);
+
+            var names = await QuerySubjectNamesAsync(conn);
+
+            names.Should().HaveCount(1);
+            names[0].Should().StartWith($"{NamePrefix}-A");
+        }
+        finally
+        {
+            await CleanupAsync(schoolA, schoolB);
+        }
+    }
+
+    [SkippableFact]
+    public async Task Tenant_context_blocks_cross_tenant_UPDATE()
+    {
+        await EnsureEnvironmentAsync();
+
+        var (schoolA, schoolB, _, subjectB) = await SeedTwoSchoolsAsync();
+        try
+        {
+            await using var conn = await OpenConnectionAsync();
+            await SetTenantAsync(conn, schoolA);
+
+            // UPDATE school B's subject by ID — without any WHERE on
+            // school_id. RLS must scope the UPDATE to only rows visible
+            // to school A, so zero rows are affected.
+            await using var cmd = new NpgsqlCommand(
+                "UPDATE subjects SET name = 'hijacked' WHERE id = @id", conn);
+            cmd.Parameters.AddWithValue("@id", subjectB);
+            var affected = await cmd.ExecuteNonQueryAsync();
+
+            affected.Should().Be(0, "RLS must prevent cross-tenant UPDATE");
+        }
+        finally
+        {
+            await CleanupAsync(schoolA, schoolB);
+        }
+    }
+
+    [SkippableFact]
+    public async Task Tenant_context_blocks_INSERT_into_other_school()
+    {
+        await EnsureEnvironmentAsync();
+
+        var (schoolA, schoolB, _, _) = await SeedTwoSchoolsAsync();
+        try
+        {
+            await using var conn = await OpenConnectionAsync();
+            await SetTenantAsync(conn, schoolA);
+
+            // WITH CHECK must reject an INSERT whose school_id is school B
+            // while the session is acting as school A.
+            await using var cmd = new NpgsqlCommand(@"
+                INSERT INTO subjects (id, school_id, name, created_at)
+                VALUES (@id, @schoolB, @name, NOW())", conn);
+            cmd.Parameters.AddWithValue("@id", Guid.NewGuid());
+            cmd.Parameters.AddWithValue("@schoolB", schoolB);
+            cmd.Parameters.AddWithValue("@name", $"{NamePrefix}-smuggled-{Guid.NewGuid():N}");
+
+            var act = async () => await cmd.ExecuteNonQueryAsync();
+            await act.Should().ThrowAsync<PostgresException>()
+                .Where(e => e.SqlState == "42501", "WITH CHECK violations surface as PG error 42501");
+        }
+        finally
+        {
+            await CleanupAsync(schoolA, schoolB);
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static async Task EnsureEnvironmentAsync()
+    {
+        Skip.If(
+            string.IsNullOrWhiteSpace(ConnectionString),
+            "EDUCONNECT_TEST_DB_URL is not set; Phase 4 RLS tests skipped.");
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT rolbypassrls OR rolsuper FROM pg_roles WHERE rolname = current_user",
+            conn);
+        var bypass = await cmd.ExecuteScalarAsync();
+        Skip.If(
+            bypass is true,
+            "Connection role has BYPASSRLS or SUPERUSER — RLS is not enforceable. " +
+            "Create an app_runtime role (NOSUPERUSER NOBYPASSRLS) and re-point EDUCONNECT_TEST_DB_URL.");
+    }
+
+    private static async Task<NpgsqlConnection> OpenConnectionAsync()
+    {
+        var conn = new NpgsqlConnection(ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private static async Task SetTenantAsync(NpgsqlConnection conn, Guid schoolId)
+    {
+        await using var cmd = new NpgsqlCommand(
+            "SELECT set_config('app.current_school_id', @id, false)", conn);
+        cmd.Parameters.AddWithValue("@id", schoolId.ToString());
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task ClearTenantAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = new NpgsqlCommand(
+            "SELECT set_config('app.current_school_id', '', false)", conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<IReadOnlyList<string>> QuerySubjectNamesAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"SELECT name FROM subjects WHERE name LIKE '{NamePrefix}-%' ORDER BY name", conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add(reader.GetString(0));
+        }
+        return rows;
+    }
+
+    private static async Task<(Guid schoolA, Guid schoolB, Guid subjectA, Guid subjectB)>
+        SeedTwoSchoolsAsync()
+    {
+        var schoolA = Guid.NewGuid();
+        var schoolB = Guid.NewGuid();
+        var subjectA = Guid.NewGuid();
+        var subjectB = Guid.NewGuid();
+
+        var codeSuffixA = schoolA.ToString("N").Substring(0, 8);
+        var codeSuffixB = schoolB.ToString("N").Substring(0, 8);
+
+        await using var conn = await OpenConnectionAsync();
+        await ClearTenantAsync(conn);
+
+        await using (var cmd = new NpgsqlCommand(@"
+            INSERT INTO schools (id, name, code, address, contact_phone, contact_email, created_at, updated_at)
+            VALUES
+              (@a, @aName, @aCode, '', '+810000000001', '', NOW(), NOW()),
+              (@b, @bName, @bCode, '', '+810000000002', '', NOW(), NOW())", conn))
+        {
+            cmd.Parameters.AddWithValue("@a", schoolA);
+            cmd.Parameters.AddWithValue("@aName", $"{NamePrefix}-A-{codeSuffixA}");
+            cmd.Parameters.AddWithValue("@aCode", $"{NamePrefix}-A-{codeSuffixA}");
+            cmd.Parameters.AddWithValue("@b", schoolB);
+            cmd.Parameters.AddWithValue("@bName", $"{NamePrefix}-B-{codeSuffixB}");
+            cmd.Parameters.AddWithValue("@bCode", $"{NamePrefix}-B-{codeSuffixB}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var cmd = new NpgsqlCommand(@"
+            INSERT INTO subjects (id, school_id, name, created_at)
+            VALUES
+              (@sa, @a, @nameA, NOW()),
+              (@sb, @b, @nameB, NOW())", conn))
+        {
+            cmd.Parameters.AddWithValue("@sa", subjectA);
+            cmd.Parameters.AddWithValue("@a", schoolA);
+            cmd.Parameters.AddWithValue("@nameA", $"{NamePrefix}-A-subject-{codeSuffixA}");
+            cmd.Parameters.AddWithValue("@sb", subjectB);
+            cmd.Parameters.AddWithValue("@b", schoolB);
+            cmd.Parameters.AddWithValue("@nameB", $"{NamePrefix}-B-subject-{codeSuffixB}");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return (schoolA, schoolB, subjectA, subjectB);
+    }
+
+    private static async Task CleanupAsync(Guid schoolA, Guid schoolB)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await ClearTenantAsync(conn);
+        // Cascade from schools wipes subjects and any other tenant rows.
+        await using var cmd = new NpgsqlCommand(
+            "DELETE FROM schools WHERE id IN (@a, @b)", conn);
+        cmd.Parameters.AddWithValue("@a", schoolA);
+        cmd.Parameters.AddWithValue("@b", schoolB);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}


### PR DESCRIPTION
Adds defence-in-depth at the database level: every tenanted table carries a row-level-security policy keyed on a session GUC (app.current_school_id). A handler that forgets .Where(x => x.SchoolId == tenant) now returns zero rows because Postgres refuses to show them, not because the application asked nicely.

Migration (apps/api, 20260421142201_EnableRowLevelSecurity):
- refresh_tokens gains its own school_id column, backfilled from the user FK, made NOT NULL, FK'd to schools. Every tenanted aggregate now carries school_id directly so the policy form is uniform.
- New SQL helper current_app_school_id() reads the session GUC and returns NULL when unset/empty so anonymous paths keep working.
- ENABLE + FORCE ROW LEVEL SECURITY on every tenanted table (19 with school_id column + schools which uses id). tenant_isolation policy: USING (current_app_school_id() IS NULL OR <id or school_id> = current_app_school_id()) WITH CHECK (same). The NULL branch preserves EF's existing "!IsAuthenticated" bypass for hand-curated anonymous endpoints (login, refresh, forgot-password).

Code wiring (apps/api):
- New TenantConnectionInterceptor (scoped; takes CurrentUserService): on every physical connection open, SELECT set_config( 'app.current_school_id', <schoolId or ''>, false). Clears the GUC explicitly on every connection so pool-returns never leak tenant state.
- Registered on AddDbContext alongside AuditableEntityInterceptor.
- RefreshTokenEntity + Configuration carry the new SchoolId; the three handlers that insert refresh tokens (Login, LoginParent, Refresh) now stamp SchoolId = user.SchoolId.
- AppDbContext's global query filter for RefreshTokenEntity switches from user.SchoolId join to the direct column.

Tests:
- TenantIsolationRlsTests validates SELECT/UPDATE/INSERT against a real Postgres via EDUCONNECT_TEST_DB_URL. Auto-skips (via Xunit.SkippableFact) when the env var is unset OR the connection role has BYPASSRLS/SUPERUSER, since PG honours those role attributes over FORCE RLS. Skip messages point operators at the runtime-role setup in the docs.

Operator action required to make RLS actually isolate tenants in prod: See apps/api/docs/row-level-security.md — create an app_runtime role with NOSUPERUSER + NOBYPASSRLS and re-point DATABASE_URL at it. Until that's done, the policies are in place but a superuser connection bypasses them at the Postgres level. Migrations continue to run as the owner/superuser.

EF query filters on SchoolId are intentionally retained. Two independent layers must agree before a cross-tenant read or write can occur.

Rollback: revert this commit, then "dotnet ef database update <previous migration>". The down path drops all policies, the helper function, and the refresh_tokens.school_id column.