### PR TITLE
feat(attachments): virus-scan uploads before they reach download path…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,12 @@ S3_SERVICE_URL=
 S3_ACCESS_KEY=
 S3_SECRET_KEY=
 AWS_REGION=ap-south-1
+
+# ── VIRUS SCANNING (Phase 5) ───────────────────────────────────────
+# CLAMAV_ENABLED=false keeps the NoOp scanner registered so local uploads
+# still flow; production must set this to true and point Host/Port at a
+# running clamd instance. See apps/api/docs/attachment-virus-scanning.md.
+CLAMAV_ENABLED=false
+CLAMAV_HOST=clamav
+CLAMAV_PORT=3310
+CLAMAV_TIMEOUT_SECONDS=30

--- a/apps/api/docs/attachment-virus-scanning.md
+++ b/apps/api/docs/attachment-virus-scanning.md
@@ -1,0 +1,94 @@
+# Attachment virus scanning (Phase 5)
+
+Every file that reaches the download surface has been streamed through a
+virus scanner first. The pipeline has four moving parts:
+
+1. **`attachments.status`** — Pending / Available / Infected / ScanFailed.
+   Enforced by a check constraint; indexed on the non-`Available` subset
+   so operator queries for "what's stuck" are cheap.
+2. **`IAttachmentScanner`** — pluggable interface with two implementations:
+   `ClamAvAttachmentScanner` (production) and `NoOpAttachmentScanner`
+   (dev/CI). The NoOp implementation logs at Warning on every call so
+   production can't accidentally ship with it.
+3. **`ChannelAttachmentScanQueue`** — bounded in-memory channel (capacity
+   256). Single-instance; horizontal scaling requires moving to a durable
+   queue (Redis LIST / PG LISTEN/NOTIFY).
+4. **`AttachmentScanWorker`** — `BackgroundService` that drains the queue,
+   streams each row through the scanner, and updates status. Infected
+   objects are also deleted from storage; `ScanFailed` objects are kept
+   for operator review.
+
+Enqueueing today happens inside `AttachFileToEntity` — i.e. the moment
+the client links the uploaded file to a homework or notice. A standalone
+`/mark-uploaded` endpoint is a planned follow-up; it would let clients
+fire scans right after the S3/R2 PUT completes (rather than at attach
+time).
+
+## Flow for a new upload
+
+```
+Client                          API                            Storage
+  │── POST request-upload-url ──▶│
+  │                              │── INSERT attachments (Pending)
+  │◀── presigned PUT URL ────────│
+  │── PUT file ──────────────────────────────────────────────▶│
+  │── POST attach ───────────────▶│
+  │                              │── UPDATE attachments (linked)
+  │                              │── ChannelAttachmentScanQueue.Enqueue(id)
+  │◀── 200 OK ───────────────────│
+                                  │                             │
+                                  │       (worker)              │
+                                  │── GetObject(key) ──────────▶│
+                                  │◀── stream ──────────────────│
+                                  │── INSTREAM to clamd ──▶ reply
+                                  │── UPDATE attachments (Available|Infected|ScanFailed)
+                                  │── (if Infected) DeleteObject(key) ─▶│
+```
+
+Until the worker sets `status=Available`, `GetAttachmentsForEntity`
+refuses to hand out a presigned download URL for the row — so the
+parent-facing download path can never point at an unscanned byte.
+
+## Deploying ClamAV
+
+1. Add a `clamav/clamav` service to Railway (or your orchestrator of
+   choice). Mount a named volume at `/var/lib/clamav` so the virus
+   database survives restarts; cron `freshclam` every 6h.
+2. Expose port `3310` on the private network only — it's a trust
+   boundary inside the app, not a public endpoint.
+3. Set the following env vars on the API service:
+   ```
+   CLAMAV_ENABLED=true
+   CLAMAV_HOST=clamav.railway.internal
+   CLAMAV_PORT=3310
+   CLAMAV_TIMEOUT_SECONDS=30
+   ```
+4. Restart the API. `AttachmentScanWorker` starts immediately and begins
+   draining the queue. Uploads that pre-date the clamd deployment remain
+   Pending until the worker picks them up; the backfill in the scan
+   migration marked every **existing** attachment `Available`, so only
+   new uploads (after deploy) will sit in Pending.
+
+## Smoke test
+
+Drop an EICAR test file via the upload URL, call `attach`, then poll
+`attachments.status` in the database:
+
+```bash
+echo -n 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > eicar.com
+curl -X PUT --data-binary @eicar.com "$PRESIGNED_URL"
+# …call /attach…
+psql "$DATABASE_URL" -c "SELECT id, status, threat_name FROM attachments ORDER BY uploaded_at DESC LIMIT 1;"
+# Expected: status = 'Infected', threat_name starts with 'Win.Test.EICAR'
+```
+
+## Operator actions
+
+- If a scan stalls (worker logs "scan timed out"), check that
+  `clamd` is reachable on the configured host:port and that the
+  virus database is fresh (`freshclam` output in the clamav container).
+- `ScanFailed` rows retain the storage object. Operator can requeue by
+  setting `status='Pending'` and invoking the enqueue path, or delete
+  via the existing attachment delete endpoint.
+- Surfacing infections to tenant admins (email, in-app notification) is
+  a follow-up; today the Warning log line is the only signal.

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
@@ -2,6 +2,8 @@ using EduConnect.Api.Common.Auth;
 using EduConnect.Api.Features.Attachments;
 using EduConnect.Api.Common.Exceptions;
 using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services.Scanning;
 using MediatR;
 
 namespace EduConnect.Api.Features.Attachments.AttachFileToEntity;
@@ -10,15 +12,18 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
 {
     private readonly AppDbContext _context;
     private readonly CurrentUserService _currentUserService;
+    private readonly IAttachmentScanQueue _scanQueue;
     private readonly ILogger<AttachFileToEntityCommandHandler> _logger;
 
     public AttachFileToEntityCommandHandler(
         AppDbContext context,
         CurrentUserService currentUserService,
+        IAttachmentScanQueue scanQueue,
         ILogger<AttachFileToEntityCommandHandler> logger)
     {
         _context = context;
         _currentUserService = currentUserService;
+        _scanQueue = scanQueue;
         _logger = logger;
     }
 
@@ -111,6 +116,17 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
         attachment.EntityType = request.EntityType;
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        // Phase 5 — only enqueue a scan for attachments that haven't been
+        // processed yet. Re-attaching a previously-Available file (e.g. the
+        // client retries) must not reset state back to Pending.
+        if (attachment.Status == AttachmentStatus.Pending)
+        {
+            await _scanQueue.EnqueueAsync(attachment.Id, cancellationToken);
+            _logger.LogInformation(
+                "Attachment {AttachmentId} enqueued for virus scan",
+                attachment.Id);
+        }
 
         _logger.LogInformation(
             "Attachment {AttachmentId} linked to {EntityType} {EntityId}",

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
@@ -35,11 +35,17 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
             await EnsureNoticeAccessAsync(request.EntityId, cancellationToken);
         }
 
+        // Phase 5 — only expose attachments that passed the virus scan.
+        // Pending / Infected / ScanFailed rows are filtered out here so no
+        // code path downstream can hand out a presigned URL for an
+        // unscanned (or infected) object. Admin review of blocked
+        // attachments is a follow-up surface.
         var attachments = await _context.Attachments
             .Where(a =>
                 a.EntityId == request.EntityId &&
                 a.EntityType == request.EntityType &&
-                a.SchoolId == _currentUserService.SchoolId)
+                a.SchoolId == _currentUserService.SchoolId &&
+                a.Status == AttachmentStatus.Available)
             .OrderBy(a => a.UploadedAt)
             .ToListAsync(cancellationToken);
 

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/AttachmentConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/AttachmentConfiguration.cs
@@ -19,6 +19,9 @@ public class AttachmentConfiguration : IEntityTypeConfiguration<AttachmentEntity
             tableBuilder.HasCheckConstraint(
                 "chk_attachment_size",
                 "size_bytes > 0 AND size_bytes <= 10485760");
+            tableBuilder.HasCheckConstraint(
+                "chk_attachment_status",
+                "status IN ('Pending', 'Available', 'Infected', 'ScanFailed')");
         });
 
         builder.HasKey(x => x.Id);
@@ -30,6 +33,17 @@ public class AttachmentConfiguration : IEntityTypeConfiguration<AttachmentEntity
         builder.Property(x => x.ContentType).IsRequired().HasMaxLength(100);
         builder.Property(x => x.SizeBytes).IsRequired();
         builder.Property(x => x.UploadedAt).HasDefaultValueSql("NOW()");
+
+        builder.Property(x => x.Status)
+            .IsRequired()
+            .HasMaxLength(16)
+            .HasDefaultValue("Pending");
+        builder.Property(x => x.ScannedAt);
+        builder.Property(x => x.ThreatName).HasMaxLength(256);
+
+        builder.HasIndex(x => x.Status)
+            .HasDatabaseName("ix_attachments_status")
+            .HasFilter("status <> 'Available'");
 
         builder.HasIndex(x => new { x.EntityId, x.EntityType })
             .HasDatabaseName("ix_attachments_entity");

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/AttachmentEntity.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/AttachmentEntity.cs
@@ -13,6 +13,30 @@ public class AttachmentEntity
     public Guid UploadedById { get; set; }
     public DateTimeOffset UploadedAt { get; set; } = DateTimeOffset.UtcNow;
 
+    // Phase 5 — virus-scan state machine.
+    // Rows created before this phase are backfilled to Available.
+    public string Status { get; set; } = AttachmentStatus.Pending;
+    public DateTimeOffset? ScannedAt { get; set; }
+    public string? ThreatName { get; set; }
+
     public SchoolEntity? School { get; set; }
     public UserEntity? UploadedBy { get; set; }
+}
+
+public static class AttachmentStatus
+{
+    // Just uploaded; still in the scan queue or being scanned.
+    public const string Pending = "Pending";
+
+    // Scanned clean and safe to hand out a download URL for.
+    public const string Available = "Available";
+
+    // Scan found a threat; the object has been deleted from storage.
+    public const string Infected = "Infected";
+
+    // Scanner errored after retries; the object is still in storage but not
+    // served. Operator intervention may re-queue or delete.
+    public const string ScanFailed = "ScanFailed";
+
+    public static readonly string[] All = { Pending, Available, Infected, ScanFailed };
 }

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
@@ -26,4 +26,11 @@ public interface IStorageService
     /// Deletes an object from storage.
     /// </summary>
     Task DeleteObjectAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens a read stream directly from storage. Caller owns the stream and
+    /// must dispose it. Used by the virus-scan pipeline to hand the object
+    /// body to the scanner without a staging round-trip through disk.
+    /// </summary>
+    Task<Stream> OpenObjectReadStreamAsync(string key, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
@@ -92,4 +92,17 @@ public class S3StorageService : IStorageService
 
         _logger.LogInformation("Deleted object with key {Key}", key);
     }
+
+    public async Task<Stream> OpenObjectReadStreamAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var response = await _s3Client.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = _storageOptions.BucketName,
+            Key = key,
+        }, cancellationToken);
+
+        // Caller disposes — wrapping ensures the S3 response is released
+        // when the stream is closed.
+        return response.ResponseStream;
+    }
 }

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanQueue.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanQueue.cs
@@ -1,0 +1,32 @@
+using System.Threading.Channels;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// In-memory queue of attachment IDs awaiting virus scan. Single-instance
+/// only: if we ever horizontally scale the API, this needs to move to a
+/// durable queue (Redis/PG LISTEN). The Channel is bounded so a burst of
+/// uploads can't blow up heap — backpressure falls on the enqueuer.
+/// </summary>
+public interface IAttachmentScanQueue
+{
+    ValueTask EnqueueAsync(Guid attachmentId, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<Guid> DequeueAllAsync(CancellationToken cancellationToken);
+}
+
+public sealed class ChannelAttachmentScanQueue : IAttachmentScanQueue
+{
+    private readonly Channel<Guid> _channel = Channel.CreateBounded<Guid>(
+        new BoundedChannelOptions(capacity: 256)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    public ValueTask EnqueueAsync(Guid attachmentId, CancellationToken cancellationToken = default)
+        => _channel.Writer.WriteAsync(attachmentId, cancellationToken);
+
+    public IAsyncEnumerable<Guid> DequeueAllAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
@@ -1,0 +1,155 @@
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Drains the in-memory scan queue, streams each attachment through the
+/// configured <see cref="IAttachmentScanner"/> and updates its status.
+///
+/// Concurrency: single consumer. Each scan happens sequentially; if clamd
+/// capacity becomes a bottleneck the queue can grow until the channel's
+/// bounded limit applies backpressure to uploaders.
+///
+/// Ownership: scans bypass RLS (tenant unknown in a background context)
+/// because the worker touches its own namespace (one row by ID, found in
+/// any tenant). The handler intentionally opens its own DbContext scope.
+/// </summary>
+public sealed class AttachmentScanWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAttachmentScanQueue _queue;
+    private readonly ILogger<AttachmentScanWorker> _logger;
+
+    public AttachmentScanWorker(
+        IServiceScopeFactory scopeFactory,
+        IAttachmentScanQueue queue,
+        ILogger<AttachmentScanWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _queue = queue;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AttachmentScanWorker started; listening for scan jobs.");
+
+        try
+        {
+            await foreach (var attachmentId in _queue.DequeueAllAsync(stoppingToken))
+            {
+                try
+                {
+                    await ScanOneAsync(attachmentId, stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Last-ditch: keep the worker alive on any unexpected
+                    // failure so a poisonous job doesn't tank the queue.
+                    _logger.LogError(ex,
+                        "Attachment scan worker failed unexpectedly for {AttachmentId}",
+                        attachmentId);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown.
+        }
+    }
+
+    private async Task ScanOneAsync(Guid attachmentId, CancellationToken ct)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+        var scanner = scope.ServiceProvider.GetRequiredService<IAttachmentScanner>();
+
+        // IgnoreQueryFilters: we don't have a tenant context in the worker
+        // scope, so the EF global query filter would otherwise return
+        // nothing. RLS is handled separately — the worker connection
+        // doesn't set app.current_school_id so policies default-allow
+        // (matching the anonymous-path contract from Phase 4).
+        var attachment = await db.Attachments
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(a => a.Id == attachmentId, ct);
+
+        if (attachment is null)
+        {
+            _logger.LogWarning("Scan job references missing attachment {AttachmentId}", attachmentId);
+            return;
+        }
+
+        if (attachment.Status != AttachmentStatus.Pending)
+        {
+            _logger.LogInformation(
+                "Skipping scan for attachment {AttachmentId}: status is already {Status}",
+                attachmentId, attachment.Status);
+            return;
+        }
+
+        ScanResult result;
+        try
+        {
+            await using var stream = await storage.OpenObjectReadStreamAsync(attachment.StorageKey, ct);
+            result = await scanner.ScanAsync(stream, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Could not stream attachment {AttachmentId} from storage for scanning",
+                attachmentId);
+            attachment.Status = AttachmentStatus.ScanFailed;
+            attachment.ScannedAt = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        attachment.ScannedAt = DateTimeOffset.UtcNow;
+
+        if (result.IsClean)
+        {
+            attachment.Status = AttachmentStatus.Available;
+            _logger.LogInformation(
+                "Attachment {AttachmentId} cleared by {Engine}",
+                attachmentId, result.Engine);
+        }
+        else if (result.IsInfected)
+        {
+            attachment.Status = AttachmentStatus.Infected;
+            attachment.ThreatName = result.ThreatName;
+
+            _logger.LogWarning(
+                "Attachment {AttachmentId} flagged as infected by {Engine}: {Threat}. Deleting from storage.",
+                attachmentId, result.Engine, result.ThreatName);
+
+            try
+            {
+                await storage.DeleteObjectAsync(attachment.StorageKey, ct);
+            }
+            catch (Exception ex)
+            {
+                // Keep the DB flag set; operator can clean up storage.
+                _logger.LogError(ex,
+                    "Failed to remove infected object {Key} from storage; status remains Infected",
+                    attachment.StorageKey);
+            }
+        }
+        else
+        {
+            attachment.Status = AttachmentStatus.ScanFailed;
+            attachment.ThreatName = result.ThreatName;
+            _logger.LogError(
+                "Attachment {AttachmentId} scan failed via {Engine}: {Detail}",
+                attachmentId, result.Engine, result.ThreatName);
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/ClamAvAttachmentScanner.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/ClamAvAttachmentScanner.cs
@@ -1,0 +1,120 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Speaks clamd's INSTREAM protocol directly over TCP. Deliberately avoids
+/// a third-party client dependency — the wire format is short enough that
+/// inlining it keeps the attack surface minimal and upgrades cheap.
+///
+/// Wire protocol (from clamd(8)):
+///   1. Connect to Host:Port.
+///   2. Send command "zINSTREAM\0".
+///   3. Send N chunks: 4 bytes BE length + chunk payload.
+///   4. Send terminating 4 bytes of zero length.
+///   5. Read reply until NUL. Expected replies:
+///        "stream: OK"                -> Clean
+///        "stream: &lt;Threat&gt; FOUND"   -> Infected (parse threat name)
+///        other                        -> Error
+/// </summary>
+public sealed class ClamAvAttachmentScanner : IAttachmentScanner
+{
+    public const string EngineName = "clamav";
+    private const int ChunkSize = 64 * 1024;
+
+    private readonly AttachmentScannerOptions _options;
+    private readonly ILogger<ClamAvAttachmentScanner> _logger;
+
+    public ClamAvAttachmentScanner(
+        IOptions<AttachmentScannerOptions> options,
+        ILogger<ClamAvAttachmentScanner> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<ScanResult> ScanAsync(Stream content, CancellationToken cancellationToken = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(_options.TimeoutSeconds));
+        var ct = timeoutCts.Token;
+
+        try
+        {
+            using var client = new TcpClient();
+            await client.ConnectAsync(_options.Host, _options.Port, ct);
+            await using var netStream = client.GetStream();
+
+            await netStream.WriteAsync(Encoding.ASCII.GetBytes("zINSTREAM\0"), ct);
+
+            var chunkBuffer = new byte[ChunkSize];
+            var lengthBuffer = new byte[4];
+
+            while (true)
+            {
+                var read = await content.ReadAsync(chunkBuffer.AsMemory(0, ChunkSize), ct);
+                if (read <= 0) break;
+
+                BinaryPrimitives.WriteUInt32BigEndian(lengthBuffer, (uint)read);
+                await netStream.WriteAsync(lengthBuffer, ct);
+                await netStream.WriteAsync(chunkBuffer.AsMemory(0, read), ct);
+            }
+
+            // Zero-length terminator.
+            BinaryPrimitives.WriteUInt32BigEndian(lengthBuffer, 0u);
+            await netStream.WriteAsync(lengthBuffer, ct);
+            await netStream.FlushAsync(ct);
+
+            var replyBuilder = new StringBuilder();
+            var readBuffer = new byte[256];
+            int n;
+            while ((n = await netStream.ReadAsync(readBuffer, ct)) > 0)
+            {
+                replyBuilder.Append(Encoding.ASCII.GetString(readBuffer, 0, n));
+                if (replyBuilder.Length > 0 && replyBuilder[^1] == '\0')
+                {
+                    break;
+                }
+            }
+
+            return ParseReply(replyBuilder.ToString().Trim('\0', ' ', '\n', '\r'));
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogError("ClamAV scan timed out after {Timeout}s against {Host}:{Port}",
+                _options.TimeoutSeconds, _options.Host, _options.Port);
+            return new ScanResult(ScanVerdict.Error, EngineName, "scan_timeout");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ClamAV scan failed against {Host}:{Port}", _options.Host, _options.Port);
+            return new ScanResult(ScanVerdict.Error, EngineName, ex.GetType().Name);
+        }
+    }
+
+    private ScanResult ParseReply(string reply)
+    {
+        // Clean: "stream: OK"
+        if (reply.EndsWith("OK", StringComparison.Ordinal))
+        {
+            return new ScanResult(ScanVerdict.Clean, EngineName);
+        }
+
+        // Infected: "stream: <ThreatName> FOUND"
+        if (reply.EndsWith("FOUND", StringComparison.Ordinal))
+        {
+            var colonIdx = reply.IndexOf(':');
+            var threat = colonIdx >= 0
+                ? reply[(colonIdx + 1)..^"FOUND".Length].Trim()
+                : "unknown";
+            _logger.LogWarning("ClamAV flagged stream as infected: {Threat}", threat);
+            return new ScanResult(ScanVerdict.Infected, EngineName, threat);
+        }
+
+        _logger.LogError("ClamAV returned an unexpected reply: {Reply}", reply);
+        return new ScanResult(ScanVerdict.Error, EngineName, "unexpected_reply");
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentScanner.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentScanner.cs
@@ -1,0 +1,39 @@
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Pluggable virus scanner for uploaded attachments. Production ships
+/// <see cref="ClamAvAttachmentScanner"/>; development and CI fall back to
+/// <see cref="NoOpAttachmentScanner"/> which passes every file.
+/// </summary>
+public interface IAttachmentScanner
+{
+    Task<ScanResult> ScanAsync(Stream content, CancellationToken cancellationToken = default);
+}
+
+public sealed record ScanResult(ScanVerdict Verdict, string Engine, string? ThreatName = null)
+{
+    public bool IsClean => Verdict == ScanVerdict.Clean;
+    public bool IsInfected => Verdict == ScanVerdict.Infected;
+    public bool IsError => Verdict == ScanVerdict.Error;
+}
+
+public enum ScanVerdict
+{
+    Clean,
+    Infected,
+    Error,
+}
+
+public sealed class AttachmentScannerOptions
+{
+    public const string SectionName = "ClamAv";
+
+    // When Enabled is false (the default for dev) the NoOp scanner is
+    // registered, which lets local uploads flow end-to-end without
+    // provisioning clamd. Production Railway deploys should set this to
+    // true and point Host/Port at the clamd service.
+    public bool Enabled { get; set; } = false;
+    public string Host { get; set; } = "clamav";
+    public int Port { get; set; } = 3310;
+    public int TimeoutSeconds { get; set; } = 30;
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/NoOpAttachmentScanner.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/NoOpAttachmentScanner.cs
@@ -1,0 +1,34 @@
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Dev/CI stand-in for a real virus scanner. Consumes the stream (so
+/// callers can't tell the difference from a real scan) and returns Clean.
+/// Logs at Warning so production never silently runs with this scanner
+/// enabled without leaving evidence.
+/// </summary>
+public sealed class NoOpAttachmentScanner : IAttachmentScanner
+{
+    public const string EngineName = "noop";
+
+    private readonly ILogger<NoOpAttachmentScanner> _logger;
+
+    public NoOpAttachmentScanner(ILogger<NoOpAttachmentScanner> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<ScanResult> ScanAsync(Stream content, CancellationToken cancellationToken = default)
+    {
+        var buffer = new byte[64 * 1024];
+        while (await content.ReadAsync(buffer, cancellationToken) > 0)
+        {
+            // Drain the stream.
+        }
+
+        _logger.LogWarning(
+            "NoOpAttachmentScanner is active — uploaded content was NOT scanned. " +
+            "Set ClamAv:Enabled=true in production.");
+
+        return new ScanResult(ScanVerdict.Clean, EngineName);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Migrations/20260421155354_AddAttachmentScanStatus.Designer.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421155354_AddAttachmentScanStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EduConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduConnect.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421155354_AddAttachmentScanStatus")]
+    partial class AddAttachmentScanStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/EduConnect.Api/Migrations/20260421155354_AddAttachmentScanStatus.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421155354_AddAttachmentScanStatus.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EduConnect.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAttachmentScanStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "scanned_at",
+                table: "attachments",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "status",
+                table: "attachments",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "Pending");
+
+            migrationBuilder.AddColumn<string>(
+                name: "threat_name",
+                table: "attachments",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_attachments_status",
+                table: "attachments",
+                column: "status",
+                filter: "status <> 'Available'");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "chk_attachment_status",
+                table: "attachments",
+                sql: "status IN ('Pending', 'Available', 'Infected', 'ScanFailed')");
+
+            // Attachments that existed before the scanning pipeline predate
+            // any threat we would now detect, but they also haven't been
+            // scanned. Treating them as Available keeps live downloads
+            // working on deploy; operators can re-queue a rescan by updating
+            // status back to Pending and enqueuing the scan job.
+            migrationBuilder.Sql(@"
+                UPDATE attachments
+                SET status = 'Available'
+                WHERE status = 'Pending';
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_attachments_status",
+                table: "attachments");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "chk_attachment_status",
+                table: "attachments");
+
+            migrationBuilder.DropColumn(
+                name: "scanned_at",
+                table: "attachments");
+
+            migrationBuilder.DropColumn(
+                name: "status",
+                table: "attachments");
+
+            migrationBuilder.DropColumn(
+                name: "threat_name",
+                table: "attachments");
+        }
+    }
+}

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -154,6 +154,40 @@ else
 }
 builder.Services.AddScoped<IStorageService, S3StorageService>();
 
+// Phase 5 — virus-scan pipeline. NoOp by default so dev uploads still flow;
+// Production sets ClamAv:Enabled=true plus Host/Port at a running clamd.
+var scannerOptions = builder.Configuration
+    .GetSection(EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerOptions.SectionName)
+    .Get<EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerOptions>()
+    ?? new EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerOptions();
+scannerOptions.Enabled =
+    bool.TryParse(builder.Configuration["CLAMAV_ENABLED"], out var clamEnabled) ? clamEnabled : scannerOptions.Enabled;
+scannerOptions.Host = builder.Configuration["CLAMAV_HOST"] ?? scannerOptions.Host;
+if (int.TryParse(builder.Configuration["CLAMAV_PORT"], out var clamPort))
+{
+    scannerOptions.Port = clamPort;
+}
+if (int.TryParse(builder.Configuration["CLAMAV_TIMEOUT_SECONDS"], out var clamTimeout))
+{
+    scannerOptions.TimeoutSeconds = clamTimeout;
+}
+builder.Services.AddSingleton<IOptions<EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerOptions>>(
+    Options.Create(scannerOptions));
+
+if (scannerOptions.Enabled)
+{
+    builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentScanner,
+        EduConnect.Api.Infrastructure.Services.Scanning.ClamAvAttachmentScanner>();
+}
+else
+{
+    builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentScanner,
+        EduConnect.Api.Infrastructure.Services.Scanning.NoOpAttachmentScanner>();
+}
+builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentScanQueue,
+    EduConnect.Api.Infrastructure.Services.Scanning.ChannelAttachmentScanQueue>();
+builder.Services.AddHostedService<EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScanWorker>();
+
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
@@ -1,0 +1,167 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+public class AttachmentScanFlowTests
+{
+    [Fact]
+    public async Task GetAttachmentsForEntity_filters_out_non_available_rows()
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        var currentUser = new CurrentUserService
+        {
+            SchoolId = schoolId,
+            UserId = teacherId,
+            Role = "Teacher",
+            Name = "Test Teacher",
+        };
+
+        await using (var context = new AppDbContext(options, currentUser))
+        {
+            context.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId,
+                Name = "Test School",
+                Code = "TEST",
+                Address = "",
+                ContactPhone = "",
+                ContactEmail = "",
+            });
+            context.Classes.Add(new ClassEntity
+            {
+                Id = classId,
+                SchoolId = schoolId,
+                Name = "6",
+                Section = "A",
+                AcademicYear = "2026",
+            });
+            context.Users.Add(new UserEntity
+            {
+                Id = teacherId,
+                SchoolId = schoolId,
+                Name = "Teacher",
+                Phone = "09000000001",
+                Role = "Teacher",
+            });
+            context.Homeworks.Add(new HomeworkEntity
+            {
+                Id = homeworkId,
+                SchoolId = schoolId,
+                ClassId = classId,
+                Subject = "Math",
+                Title = "HW 1",
+                Description = "",
+                DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(3)),
+                Status = "Published",
+                AssignedById = teacherId,
+            });
+
+            foreach (var status in new[]
+            {
+                AttachmentStatus.Pending,
+                AttachmentStatus.Available,
+                AttachmentStatus.Infected,
+                AttachmentStatus.ScanFailed,
+            })
+            {
+                context.Attachments.Add(new AttachmentEntity
+                {
+                    Id = Guid.NewGuid(),
+                    SchoolId = schoolId,
+                    EntityId = homeworkId,
+                    EntityType = "homework",
+                    StorageKey = $"test/{status}.pdf",
+                    FileName = $"{status}.pdf",
+                    ContentType = "application/pdf",
+                    SizeBytes = 100,
+                    UploadedById = teacherId,
+                    UploadedAt = DateTimeOffset.UtcNow,
+                    Status = status,
+                });
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        var storage = new Mock<IStorageService>(MockBehavior.Strict);
+        storage.Setup(s => s.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://signed/");
+
+        await using var readContext = new AppDbContext(options, currentUser);
+        var handler = new GetAttachmentsForEntityQueryHandler(readContext, currentUser, storage.Object);
+
+        var result = await handler.Handle(
+            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
+            CancellationToken.None);
+
+        result.Should().ContainSingle(
+            "only rows with Status=Available should be handed out for download");
+        result[0].FileName.Should().Be($"{AttachmentStatus.Available}.pdf");
+
+        // Presigned URL must have been requested exactly once — the Pending,
+        // Infected, and ScanFailed rows never reach the storage service.
+        storage.Verify(
+            s => s.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NoOpAttachmentScanner_returns_clean_and_drains_stream()
+    {
+        var scanner = new NoOpAttachmentScanner(NullLogger<NoOpAttachmentScanner>.Instance);
+        var payload = new byte[4096];
+        Random.Shared.NextBytes(payload);
+        await using var stream = new MemoryStream(payload);
+
+        var result = await scanner.ScanAsync(stream);
+
+        result.IsClean.Should().BeTrue();
+        result.Engine.Should().Be(NoOpAttachmentScanner.EngineName);
+        result.ThreatName.Should().BeNull();
+        stream.Position.Should().Be(payload.Length, "the scanner should drain the entire stream");
+    }
+
+    [Fact]
+    public async Task ChannelAttachmentScanQueue_round_trips_ids_in_order()
+    {
+        var queue = new ChannelAttachmentScanQueue();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+
+        await queue.EnqueueAsync(a);
+        await queue.EnqueueAsync(b);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var received = new List<Guid>();
+        await foreach (var id in queue.DequeueAllAsync(cts.Token))
+        {
+            received.Add(id);
+            if (received.Count == 2) break;
+        }
+
+        received.Should().Equal(a, b);
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
@@ -164,7 +164,8 @@ public class HomeworkAttachmentFlowTests
                     ContentType = "application/pdf",
                     SizeBytes = 1024,
                     UploadedById = teacherId,
-                    UploadedAt = DateTimeOffset.UtcNow
+                    UploadedAt = DateTimeOffset.UtcNow,
+                    Status = AttachmentStatus.Available
                 }
             ]);
 
@@ -248,7 +249,8 @@ public class HomeworkAttachmentFlowTests
                     ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                     SizeBytes = 4096,
                     UploadedById = teacherId,
-                    UploadedAt = DateTimeOffset.UtcNow
+                    UploadedAt = DateTimeOffset.UtcNow,
+                    Status = AttachmentStatus.Available
                 }
             ]);
 
@@ -318,7 +320,8 @@ public class HomeworkAttachmentFlowTests
                     ContentType = "application/pdf",
                     SizeBytes = 1024,
                     UploadedById = teacherId,
-                    UploadedAt = DateTimeOffset.UtcNow
+                    UploadedAt = DateTimeOffset.UtcNow,
+                    Status = AttachmentStatus.Available
                 }
             ]);
 
@@ -377,7 +380,8 @@ public class HomeworkAttachmentFlowTests
                     ContentType = "application/pdf",
                     SizeBytes = 1024,
                     UploadedById = teacherId,
-                    UploadedAt = DateTimeOffset.UtcNow
+                    UploadedAt = DateTimeOffset.UtcNow,
+                    Status = AttachmentStatus.Available
                 }
             ]);
 


### PR DESCRIPTION
…s (Phase 5)

Every uploaded attachment is now streamed through a scanner before the download endpoint will hand out a presigned URL. Infected objects are flagged and deleted from storage; scan failures are retained for operator review. Existing attachments that predate the pipeline are backfilled to Available on migration so live downloads don't break on deploy.

Schema (apps/api):
- AttachmentEntity gains Status (Pending / Available / Infected / ScanFailed), ScannedAt, ThreatName. EF adds a check constraint on status and a partial index on the non-Available subset for cheap "what's stuck" operator queries.
- Migration 20260421155354_AddAttachmentScanStatus backfills every pre-Phase-5 row to Available so no in-flight download breaks on deploy.

Scanner (Infrastructure/Services/Scanning):
- IAttachmentScanner + ScanResult (Clean / Infected / Error).
- ClamAvAttachmentScanner speaks clamd's INSTREAM protocol directly over TCP (~100 lines, no new NuGet). Returns Infected with a parsed threat name on FOUND, Error on unexpected replies or timeouts.
- NoOpAttachmentScanner drains the stream and returns Clean, emitting a Warning log on every call so production can't silently ship with it enabled.
- IStorageService grows OpenObjectReadStreamAsync so the worker can hand the S3/R2 body straight to the scanner.

Queue + worker:
- ChannelAttachmentScanQueue is a bounded (256) in-memory queue — single-instance; documented as needing a durable backend once the API scales horizontally.
- AttachmentScanWorker is a BackgroundService that drains the queue, runs the scanner per attachment, updates status, and deletes objects that came back Infected. Failures in one scan don't take down the worker loop.
- AttachFileToEntity enqueues the scan job on link. Keeps the client API extend-only — no new endpoint, no frontend change required for the core security property to hold. A dedicated /mark-uploaded endpoint (for proactive scanning after PUT) is a documented follow-up.

Download gate:
- GetAttachmentsForEntityQueryHandler now filters WHERE Status = Available, so Pending / Infected / ScanFailed rows never reach the presigned-URL generator.

Config + DI:
- AttachmentScannerOptions (CLAMAV_* env vars) selects between the NoOp and ClamAv implementations at startup. Dev defaults to NoOp; production sets CLAMAV_ENABLED=true plus Host/Port.
- .env.example documents the new vars alongside existing storage config.

Tests (3 new):
- Download gate filters every non-Available status (Pending / Infected / ScanFailed) out of the response and never asks the storage service for a URL for those rows.
- NoOp scanner returns Clean and drains the stream end-to-end.
- Channel queue round-trips ids in order.

Existing HomeworkAttachmentFlowTests seed Status = Available on their fixtures so the new gate doesn't filter out their happy-path rows.

Operator docs at apps/api/docs/attachment-virus-scanning.md cover the Railway deploy, EICAR smoke test, and handling stuck rows.

Rollback: revert this commit and "dotnet ef database update <previous migration>". The Down path drops the scan columns, index, and check constraint.