### PR TITLE
feat(homework): add HomeworkSubmission aggregate + student submit flo…

### DIFF
--- a/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
@@ -26,6 +26,10 @@ using EduConnect.Api.Features.Homework.UpdateHomework;
 using EduConnect.Api.Features.Homework.SubmitHomeworkForApproval;
 using EduConnect.Api.Features.Homework.ApproveHomework;
 using EduConnect.Api.Features.Homework.RejectHomework;
+using EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+using EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+using EduConnect.Api.Features.HomeworkSubmissions.GetSubmissionsByHomework;
+using EduConnect.Api.Features.HomeworkSubmissions.GetMySubmissions;
 using EduConnect.Api.Features.Notices.CreateNotice;
 using EduConnect.Api.Features.Notices.PublishNotice;
 using EduConnect.Api.Features.Notices.GetNotices;
@@ -85,6 +89,7 @@ public static class EndpointRouteBuilderExtensions
         app.MapAuthEndpoints();
         app.MapAttendanceEndpoints();
         app.MapHomeworkEndpoints();
+        app.MapHomeworkSubmissionEndpoints();
         app.MapNoticeEndpoints();
         app.MapStudentEndpoints();
         app.MapParentEndpoints();
@@ -141,6 +146,24 @@ public static class EndpointRouteBuilderExtensions
         group.MapPut("/{id}/submit", SubmitHomeworkForApprovalEndpoint.Handle).WithName("SubmitHomeworkForApproval");
         group.MapPut("/{id}/approve", ApproveHomeworkEndpoint.Handle).WithName("ApproveHomework");
         group.MapPut("/{id}/reject", RejectHomeworkEndpoint.Handle).WithName("RejectHomework");
+    }
+
+    private static void MapHomeworkSubmissionEndpoints(this WebApplication app)
+    {
+        // Student-submission surface lives at /homework/{id}/submissions so it
+        // doesn't collide with the teacher→admin "/{id}/submit" approval
+        // route (different verb + URL).
+        var homework = app.MapGroup("/api/homework").WithTags("HomeworkSubmissions").RequireAuthorization();
+        homework.MapPost("/{id}/submissions", SubmitHomeworkEndpoint.Handle)
+            .WithName("SubmitHomework");
+        homework.MapGet("/{id}/submissions", GetSubmissionsByHomeworkEndpoint.Handle)
+            .WithName("GetSubmissionsByHomework");
+
+        var submissions = app.MapGroup("/api/homework-submissions").WithTags("HomeworkSubmissions").RequireAuthorization();
+        submissions.MapPut("/{id}/grade", GradeHomeworkSubmissionEndpoint.Handle)
+            .WithName("GradeHomeworkSubmission");
+        submissions.MapGet("/mine", GetMySubmissionsEndpoint.Handle)
+            .WithName("GetMyHomeworkSubmissions");
     }
 
     private static void MapNoticeEndpoints(this WebApplication app)

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandValidator.cs
@@ -4,7 +4,7 @@ namespace EduConnect.Api.Features.Attachments.AttachFileToEntity;
 
 public class AttachFileToEntityCommandValidator : AbstractValidator<AttachFileToEntityCommand>
 {
-    private static readonly string[] AllowedEntityTypes = { "homework", "notice" };
+    private static readonly string[] AllowedEntityTypes = { "homework", "homework_submission", "notice" };
 
     public AttachFileToEntityCommandValidator()
     {
@@ -17,6 +17,6 @@ public class AttachFileToEntityCommandValidator : AbstractValidator<AttachFileTo
         RuleFor(x => x.EntityType)
             .NotEmpty().WithMessage("Entity type is required.")
             .Must(et => AllowedEntityTypes.Contains(et))
-            .WithMessage("Entity type must be 'homework' or 'notice'.");
+            .WithMessage("Entity type must be 'homework', 'homework_submission', or 'notice'.");
     }
 }

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachmentRules.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachmentRules.cs
@@ -7,6 +7,7 @@ public static class AttachmentFeatureRules
     public static readonly string[] SupportedEntityTypes =
     [
         "homework",
+        "homework_submission",
         "notice"
     ];
 
@@ -19,6 +20,29 @@ public static class AttachmentFeatureRules
 
     public static readonly string[] HomeworkAllowedExtensions =
     [
+        ".pdf",
+        ".doc",
+        ".docx"
+    ];
+
+    // Student submissions allow the same set as the homework itself plus
+    // common image formats (photo of handwritten work).
+    public static readonly string[] HomeworkSubmissionAllowedContentTypes =
+    [
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ];
+
+    public static readonly string[] HomeworkSubmissionAllowedExtensions =
+    [
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".webp",
         ".pdf",
         ".doc",
         ".docx"
@@ -45,6 +69,7 @@ public static class AttachmentFeatureRules
         entityType switch
         {
             "homework" => HomeworkAllowedContentTypes,
+            "homework_submission" => HomeworkSubmissionAllowedContentTypes,
             "notice" => NoticeAllowedContentTypes,
             _ => Array.Empty<string>()
         };
@@ -53,6 +78,7 @@ public static class AttachmentFeatureRules
         entityType switch
         {
             "homework" => HomeworkAllowedExtensions,
+            "homework_submission" => HomeworkSubmissionAllowedExtensions,
             "notice" => NoticeAllowedExtensions,
             _ => Array.Empty<string>()
         };

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsEndpoint.cs
@@ -1,0 +1,17 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetMySubmissions;
+
+public static class GetMySubmissionsEndpoint
+{
+    public static async Task<IResult> Handle(
+        Guid? studentId,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetMySubmissionsQuery(studentId),
+            cancellationToken);
+        return Results.Ok(result);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsQuery.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsQuery.cs
@@ -1,0 +1,20 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetMySubmissions;
+
+public record GetMySubmissionsQuery(Guid? StudentId)
+    : IRequest<IReadOnlyList<MyHomeworkSubmissionItem>>;
+
+public record MyHomeworkSubmissionItem(
+    Guid SubmissionId,
+    Guid HomeworkId,
+    string HomeworkTitle,
+    string HomeworkSubject,
+    Guid StudentId,
+    string StudentName,
+    string Status,
+    string? BodyText,
+    string? Grade,
+    string? Feedback,
+    DateTimeOffset SubmittedAt,
+    DateTimeOffset? GradedAt);

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetMySubmissions/GetMySubmissionsQueryHandler.cs
@@ -1,0 +1,78 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Infrastructure.Database;
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetMySubmissions;
+
+public class GetMySubmissionsQueryHandler
+    : IRequestHandler<GetMySubmissionsQuery, IReadOnlyList<MyHomeworkSubmissionItem>>
+{
+    private readonly AppDbContext _context;
+    private readonly CurrentUserService _currentUserService;
+
+    public GetMySubmissionsQueryHandler(
+        AppDbContext context,
+        CurrentUserService currentUserService)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<IReadOnlyList<MyHomeworkSubmissionItem>> Handle(
+        GetMySubmissionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (_currentUserService.Role != "Parent")
+        {
+            throw new ForbiddenException("Only parents can view their children's submissions.");
+        }
+
+        // The parent's accessible student set = all students linked to them.
+        var myStudentIds = await _context.ParentStudentLinks
+            .Where(l =>
+                l.SchoolId == _currentUserService.SchoolId &&
+                l.ParentId == _currentUserService.UserId)
+            .Select(l => l.StudentId)
+            .ToListAsync(cancellationToken);
+
+        if (myStudentIds.Count == 0)
+        {
+            return Array.Empty<MyHomeworkSubmissionItem>();
+        }
+
+        if (request.StudentId.HasValue && !myStudentIds.Contains(request.StudentId.Value))
+        {
+            throw new ForbiddenException("You can only view submissions for your own children.");
+        }
+
+        var scopedStudentIds = request.StudentId.HasValue
+            ? new[] { request.StudentId.Value }
+            : myStudentIds.ToArray();
+
+        var rows = await (
+            from s in _context.HomeworkSubmissions
+            join hw in _context.Homeworks on s.HomeworkId equals hw.Id
+            join stu in _context.Students on s.StudentId equals stu.Id
+            where s.SchoolId == _currentUserService.SchoolId
+                  && scopedStudentIds.Contains(s.StudentId)
+                  && !hw.IsDeleted
+            orderby s.SubmittedAt descending
+            select new MyHomeworkSubmissionItem(
+                s.Id,
+                hw.Id,
+                hw.Title,
+                hw.Subject,
+                stu.Id,
+                stu.Name,
+                s.Status,
+                s.BodyText,
+                s.Grade,
+                s.Feedback,
+                s.SubmittedAt,
+                s.GradedAt))
+            .ToListAsync(cancellationToken);
+
+        return rows;
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkEndpoint.cs
@@ -1,0 +1,17 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetSubmissionsByHomework;
+
+public static class GetSubmissionsByHomeworkEndpoint
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetSubmissionsByHomeworkQuery(id),
+            cancellationToken);
+        return Results.Ok(result);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkQuery.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkQuery.cs
@@ -1,0 +1,18 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetSubmissionsByHomework;
+
+public record GetSubmissionsByHomeworkQuery(Guid HomeworkId)
+    : IRequest<IReadOnlyList<HomeworkSubmissionListItem>>;
+
+public record HomeworkSubmissionListItem(
+    Guid SubmissionId,
+    Guid StudentId,
+    string StudentName,
+    string? RollNumber,
+    string Status,
+    string? BodyText,
+    string? Grade,
+    string? Feedback,
+    DateTimeOffset SubmittedAt,
+    DateTimeOffset? GradedAt);

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GetSubmissionsByHomework/GetSubmissionsByHomeworkQueryHandler.cs
@@ -1,0 +1,80 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Infrastructure.Database;
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GetSubmissionsByHomework;
+
+public class GetSubmissionsByHomeworkQueryHandler
+    : IRequestHandler<GetSubmissionsByHomeworkQuery, IReadOnlyList<HomeworkSubmissionListItem>>
+{
+    private readonly AppDbContext _context;
+    private readonly CurrentUserService _currentUserService;
+
+    public GetSubmissionsByHomeworkQueryHandler(
+        AppDbContext context,
+        CurrentUserService currentUserService)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<IReadOnlyList<HomeworkSubmissionListItem>> Handle(
+        GetSubmissionsByHomeworkQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (_currentUserService.Role != "Teacher" && _currentUserService.Role != "Admin")
+        {
+            throw new ForbiddenException("Only teachers and admins can view homework submissions.");
+        }
+
+        var homework = await _context.Homeworks
+            .FirstOrDefaultAsync(h =>
+                h.Id == request.HomeworkId &&
+                h.SchoolId == _currentUserService.SchoolId &&
+                !h.IsDeleted,
+                cancellationToken);
+
+        if (homework is null)
+        {
+            throw new NotFoundException("Homework", request.HomeworkId.ToString());
+        }
+
+        if (_currentUserService.Role == "Teacher")
+        {
+            var isAuthor = homework.AssignedById == _currentUserService.UserId;
+            var isAssigned = await _context.TeacherClassAssignments
+                .AnyAsync(a =>
+                    a.SchoolId == _currentUserService.SchoolId &&
+                    a.TeacherId == _currentUserService.UserId &&
+                    a.ClassId == homework.ClassId,
+                    cancellationToken);
+
+            if (!isAuthor && !isAssigned)
+            {
+                throw new ForbiddenException("You are not assigned to this homework's class.");
+            }
+        }
+
+        var rows = await (
+            from s in _context.HomeworkSubmissions
+            join stu in _context.Students on s.StudentId equals stu.Id
+            where s.HomeworkId == request.HomeworkId
+                  && s.SchoolId == _currentUserService.SchoolId
+            orderby s.SubmittedAt
+            select new HomeworkSubmissionListItem(
+                s.Id,
+                stu.Id,
+                stu.Name,
+                stu.RollNumber,
+                s.Status,
+                s.BodyText,
+                s.Grade,
+                s.Feedback,
+                s.SubmittedAt,
+                s.GradedAt))
+            .ToListAsync(cancellationToken);
+
+        return rows;
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommand.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+
+public record GradeHomeworkSubmissionCommand(
+    Guid SubmissionId,
+    string Grade,
+    string? Feedback) : IRequest<GradeHomeworkSubmissionResponse>;
+
+public record GradeHomeworkSubmissionResponse(
+    Guid SubmissionId,
+    string Grade,
+    string? Feedback,
+    DateTimeOffset GradedAt);

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommandHandler.cs
@@ -1,0 +1,86 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+
+public class GradeHomeworkSubmissionCommandHandler
+    : IRequestHandler<GradeHomeworkSubmissionCommand, GradeHomeworkSubmissionResponse>
+{
+    private readonly AppDbContext _context;
+    private readonly CurrentUserService _currentUserService;
+    private readonly ILogger<GradeHomeworkSubmissionCommandHandler> _logger;
+
+    public GradeHomeworkSubmissionCommandHandler(
+        AppDbContext context,
+        CurrentUserService currentUserService,
+        ILogger<GradeHomeworkSubmissionCommandHandler> logger)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GradeHomeworkSubmissionResponse> Handle(
+        GradeHomeworkSubmissionCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (_currentUserService.Role != "Teacher" && _currentUserService.Role != "Admin")
+        {
+            throw new ForbiddenException("Only teachers and admins can grade homework submissions.");
+        }
+
+        var submission = await _context.HomeworkSubmissions
+            .Include(s => s.Homework)
+            .FirstOrDefaultAsync(s =>
+                s.Id == request.SubmissionId &&
+                s.SchoolId == _currentUserService.SchoolId,
+                cancellationToken);
+
+        if (submission is null || submission.Homework is null)
+        {
+            throw new NotFoundException("HomeworkSubmission", request.SubmissionId.ToString());
+        }
+
+        // Teachers can only grade submissions for homework they authored or
+        // for classes they're assigned to. Admin bypasses the class check.
+        if (_currentUserService.Role == "Teacher")
+        {
+            var isAuthor = submission.Homework.AssignedById == _currentUserService.UserId;
+
+            var isAssigned = await _context.TeacherClassAssignments
+                .AnyAsync(a =>
+                    a.SchoolId == _currentUserService.SchoolId &&
+                    a.TeacherId == _currentUserService.UserId &&
+                    a.ClassId == submission.Homework.ClassId,
+                    cancellationToken);
+
+            if (!isAuthor && !isAssigned)
+            {
+                throw new ForbiddenException("You are not assigned to this homework's class.");
+            }
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        submission.Grade = request.Grade;
+        submission.Feedback = request.Feedback;
+        submission.GradedById = _currentUserService.UserId;
+        submission.GradedAt = now;
+        submission.Status = HomeworkSubmissionStatus.Graded;
+        submission.UpdatedAt = now;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Homework submission {SubmissionId} graded by {UserId}",
+            submission.Id, _currentUserService.UserId);
+
+        return new GradeHomeworkSubmissionResponse(
+            submission.Id,
+            submission.Grade!,
+            submission.Feedback,
+            submission.GradedAt!.Value);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+
+public class GradeHomeworkSubmissionCommandValidator : AbstractValidator<GradeHomeworkSubmissionCommand>
+{
+    public GradeHomeworkSubmissionCommandValidator()
+    {
+        RuleFor(x => x.SubmissionId).NotEmpty();
+        RuleFor(x => x.Grade)
+            .NotEmpty().WithMessage("Grade is required.")
+            .MaximumLength(32);
+        RuleFor(x => x.Feedback)
+            .MaximumLength(2000)
+            .When(x => x.Feedback != null);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/GradeHomeworkSubmission/GradeHomeworkSubmissionEndpoint.cs
@@ -1,0 +1,20 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+
+public static class GradeHomeworkSubmissionEndpoint
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        GradeHomeworkSubmissionRequest body,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GradeHomeworkSubmissionCommand(id, body.Grade, body.Feedback),
+            cancellationToken);
+        return Results.Ok(result);
+    }
+}
+
+public record GradeHomeworkSubmissionRequest(string Grade, string? Feedback);

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommand.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+
+public record SubmitHomeworkCommand(
+    Guid HomeworkId,
+    Guid StudentId,
+    string? BodyText,
+    IReadOnlyList<Guid>? AttachmentIds) : IRequest<SubmitHomeworkResponse>;
+
+public record SubmitHomeworkResponse(
+    Guid SubmissionId,
+    string Status,
+    DateTimeOffset SubmittedAt);

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommandHandler.cs
@@ -1,0 +1,158 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+
+public class SubmitHomeworkCommandHandler
+    : IRequestHandler<SubmitHomeworkCommand, SubmitHomeworkResponse>
+{
+    private readonly AppDbContext _context;
+    private readonly CurrentUserService _currentUserService;
+    private readonly ILogger<SubmitHomeworkCommandHandler> _logger;
+
+    public SubmitHomeworkCommandHandler(
+        AppDbContext context,
+        CurrentUserService currentUserService,
+        ILogger<SubmitHomeworkCommandHandler> logger)
+    {
+        _context = context;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<SubmitHomeworkResponse> Handle(
+        SubmitHomeworkCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (_currentUserService.Role != "Parent")
+        {
+            throw new ForbiddenException("Only parents can submit homework on behalf of a student.");
+        }
+
+        // The parent must be linked to this student.
+        var link = await _context.ParentStudentLinks
+            .FirstOrDefaultAsync(l =>
+                l.SchoolId == _currentUserService.SchoolId &&
+                l.ParentId == _currentUserService.UserId &&
+                l.StudentId == request.StudentId,
+                cancellationToken);
+
+        if (link is null)
+        {
+            throw new ForbiddenException("You can only submit homework for your own child.");
+        }
+
+        var student = await _context.Students
+            .FirstOrDefaultAsync(s =>
+                s.Id == request.StudentId &&
+                s.SchoolId == _currentUserService.SchoolId &&
+                s.IsActive,
+                cancellationToken);
+        if (student is null)
+        {
+            throw new NotFoundException("Student", request.StudentId.ToString());
+        }
+
+        var homework = await _context.Homeworks
+            .FirstOrDefaultAsync(h =>
+                h.Id == request.HomeworkId &&
+                h.SchoolId == _currentUserService.SchoolId &&
+                !h.IsDeleted,
+                cancellationToken);
+        if (homework is null)
+        {
+            throw new NotFoundException("Homework", request.HomeworkId.ToString());
+        }
+
+        if (homework.Status != "Published")
+        {
+            throw new InvalidOperationException("Homework is not yet available for submission.");
+        }
+
+        if (homework.ClassId != student.ClassId)
+        {
+            throw new ForbiddenException("This homework is for a different class.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var isLate = DateOnly.FromDateTime(now.UtcDateTime) > homework.DueDate;
+        var nextStatus = isLate ? HomeworkSubmissionStatus.Late : HomeworkSubmissionStatus.Submitted;
+
+        // Upsert: one active submission per (homework, student).
+        var submission = await _context.HomeworkSubmissions
+            .FirstOrDefaultAsync(s =>
+                s.HomeworkId == request.HomeworkId &&
+                s.StudentId == request.StudentId,
+                cancellationToken);
+
+        if (submission is null)
+        {
+            submission = new HomeworkSubmissionEntity
+            {
+                Id = Guid.NewGuid(),
+                SchoolId = _currentUserService.SchoolId,
+                HomeworkId = request.HomeworkId,
+                StudentId = request.StudentId,
+                BodyText = request.BodyText,
+                Status = nextStatus,
+                SubmittedAt = now,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _context.HomeworkSubmissions.Add(submission);
+        }
+        else
+        {
+            // Teacher already graded — resubmission would overwrite feedback.
+            // Block here; a proper Return-for-redo flow (Phase 6 follow-up)
+            // will explicitly clear grade state and allow re-submission.
+            if (submission.Status == HomeworkSubmissionStatus.Graded)
+            {
+                throw new InvalidOperationException(
+                    "This submission has already been graded.");
+            }
+
+            submission.BodyText = request.BodyText;
+            submission.Status = nextStatus;
+            submission.SubmittedAt = now;
+            submission.UpdatedAt = now;
+        }
+
+        // Link any just-uploaded attachments to this submission. Only
+        // attachments the parent themselves uploaded are accepted — cross-
+        // tenant is already blocked by the SchoolId check, but we also
+        // prevent a parent from claiming another user's attachment.
+        if (request.AttachmentIds is { Count: > 0 } attachmentIds)
+        {
+            var attachments = await _context.Attachments
+                .Where(a =>
+                    attachmentIds.Contains(a.Id) &&
+                    a.SchoolId == _currentUserService.SchoolId &&
+                    a.UploadedById == _currentUserService.UserId &&
+                    (a.EntityId == null || a.EntityId == submission.Id))
+                .ToListAsync(cancellationToken);
+
+            if (attachments.Count != attachmentIds.Count)
+            {
+                throw new ForbiddenException("One or more attachments are not available for this submission.");
+            }
+
+            foreach (var attachment in attachments)
+            {
+                attachment.EntityId = submission.Id;
+                attachment.EntityType = "homework_submission";
+            }
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Homework submission {SubmissionId} recorded for student {StudentId} on homework {HomeworkId} with status {Status}",
+            submission.Id, submission.StudentId, submission.HomeworkId, submission.Status);
+
+        return new SubmitHomeworkResponse(submission.Id, submission.Status, submission.SubmittedAt);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommandValidator.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+
+public class SubmitHomeworkCommandValidator : AbstractValidator<SubmitHomeworkCommand>
+{
+    public SubmitHomeworkCommandValidator()
+    {
+        RuleFor(x => x.HomeworkId).NotEmpty().WithMessage("Homework ID is required.");
+        RuleFor(x => x.StudentId).NotEmpty().WithMessage("Student ID is required.");
+
+        RuleFor(x => x.BodyText)
+            .MaximumLength(4000)
+            .When(x => x.BodyText != null);
+
+        // A submission must have either body text or at least one attachment.
+        RuleFor(x => x)
+            .Must(c => !string.IsNullOrWhiteSpace(c.BodyText)
+                       || (c.AttachmentIds != null && c.AttachmentIds.Count > 0))
+            .WithMessage("Submission must include either text or at least one attachment.");
+    }
+}

--- a/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/HomeworkSubmissions/SubmitHomework/SubmitHomeworkEndpoint.cs
@@ -1,0 +1,26 @@
+using MediatR;
+
+namespace EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+
+public static class SubmitHomeworkEndpoint
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        SubmitHomeworkRequest body,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var command = new SubmitHomeworkCommand(
+            id,
+            body.StudentId,
+            body.BodyText,
+            body.AttachmentIds);
+        var result = await mediator.Send(command, cancellationToken);
+        return Results.Ok(result);
+    }
+}
+
+public record SubmitHomeworkRequest(
+    Guid StudentId,
+    string? BodyText,
+    IReadOnlyList<Guid>? AttachmentIds);

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/AppDbContext.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/AppDbContext.cs
@@ -28,6 +28,7 @@ public class AppDbContext : DbContext
     public DbSet<ParentStudentLinkEntity> ParentStudentLinks { get; set; }
     public DbSet<AttendanceRecordEntity> AttendanceRecords { get; set; }
     public DbSet<HomeworkEntity> Homeworks { get; set; }
+    public DbSet<HomeworkSubmissionEntity> HomeworkSubmissions { get; set; }
     public DbSet<NoticeEntity> Notices { get; set; }
     public DbSet<NoticeTargetClassEntity> NoticeTargetClasses { get; set; }
     public DbSet<SubjectEntity> Subjects { get; set; }
@@ -62,6 +63,8 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<AttendanceRecordEntity>()
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated || entity.SchoolId == _currentUserService.SchoolId);
         modelBuilder.Entity<HomeworkEntity>()
+            .HasQueryFilter(entity => !_currentUserService.IsAuthenticated || entity.SchoolId == _currentUserService.SchoolId);
+        modelBuilder.Entity<HomeworkSubmissionEntity>()
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated || entity.SchoolId == _currentUserService.SchoolId);
         modelBuilder.Entity<NoticeEntity>()
             .HasQueryFilter(entity => !_currentUserService.IsAuthenticated || entity.SchoolId == _currentUserService.SchoolId);

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/AttachmentConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/AttachmentConfiguration.cs
@@ -12,7 +12,7 @@ public class AttachmentConfiguration : IEntityTypeConfiguration<AttachmentEntity
         {
             tableBuilder.HasCheckConstraint(
                 "chk_attachment_entity_type",
-                "entity_type IS NULL OR entity_type IN ('homework', 'notice')");
+                "entity_type IS NULL OR entity_type IN ('homework', 'notice', 'homework_submission')");
             tableBuilder.HasCheckConstraint(
                 "chk_attachment_content_type",
                 "content_type IN ('image/jpeg', 'image/png', 'image/webp', 'application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')");

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/HomeworkSubmissionConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/HomeworkSubmissionConfiguration.cs
@@ -1,0 +1,58 @@
+using EduConnect.Api.Infrastructure.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EduConnect.Api.Infrastructure.Database.Configurations;
+
+public class HomeworkSubmissionConfiguration : IEntityTypeConfiguration<HomeworkSubmissionEntity>
+{
+    public void Configure(EntityTypeBuilder<HomeworkSubmissionEntity> builder)
+    {
+        builder.ToTable("homework_submissions", tableBuilder =>
+        {
+            tableBuilder.HasCheckConstraint(
+                "chk_homework_submission_status",
+                "status IN ('Submitted', 'Late', 'Graded', 'Returned')");
+        });
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.Status).IsRequired().HasMaxLength(16);
+        builder.Property(x => x.BodyText).HasMaxLength(4000);
+        builder.Property(x => x.Grade).HasMaxLength(32);
+        builder.Property(x => x.Feedback).HasMaxLength(2000);
+        builder.Property(x => x.SubmittedAt).HasDefaultValueSql("NOW()");
+        builder.Property(x => x.CreatedAt).HasDefaultValueSql("NOW()");
+        builder.Property(x => x.UpdatedAt).HasDefaultValueSql("NOW()");
+
+        // One active submission per (homework, student).
+        builder.HasIndex(x => new { x.HomeworkId, x.StudentId })
+            .IsUnique()
+            .HasDatabaseName("ux_homework_submissions_homework_student");
+
+        builder.HasIndex(x => x.SchoolId);
+        builder.HasIndex(x => x.HomeworkId);
+        builder.HasIndex(x => x.StudentId);
+
+        builder.HasOne(x => x.School)
+            .WithMany()
+            .HasForeignKey(x => x.SchoolId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Homework)
+            .WithMany()
+            .HasForeignKey(x => x.HomeworkId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Student)
+            .WithMany()
+            .HasForeignKey(x => x.StudentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.GradedBy)
+            .WithMany()
+            .HasForeignKey(x => x.GradedById)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/HomeworkSubmissionEntity.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Entities/HomeworkSubmissionEntity.cs
@@ -1,0 +1,43 @@
+namespace EduConnect.Api.Infrastructure.Database.Entities;
+
+public class HomeworkSubmissionEntity
+{
+    public Guid Id { get; set; }
+    public Guid SchoolId { get; set; }
+    public Guid HomeworkId { get; set; }
+    public Guid StudentId { get; set; }
+
+    public string Status { get; set; } = HomeworkSubmissionStatus.Submitted;
+    public string? BodyText { get; set; }
+    public DateTimeOffset SubmittedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public string? Grade { get; set; }
+    public string? Feedback { get; set; }
+    public Guid? GradedById { get; set; }
+    public DateTimeOffset? GradedAt { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public SchoolEntity? School { get; set; }
+    public HomeworkEntity? Homework { get; set; }
+    public StudentEntity? Student { get; set; }
+    public UserEntity? GradedBy { get; set; }
+}
+
+public static class HomeworkSubmissionStatus
+{
+    // Student's initial post. May become Late at save time if past due date.
+    public const string Submitted = "Submitted";
+    public const string Late = "Late";
+
+    // Teacher has scored / given feedback. Still visible to student.
+    public const string Graded = "Graded";
+
+    // Teacher asked for a redo; student can re-submit which moves it back
+    // to Submitted/Late. Not fully implemented in this phase (grade-only
+    // ships first); constant reserved so migrations don't need redoing.
+    public const string Returned = "Returned";
+
+    public static readonly string[] All = { Submitted, Late, Graded, Returned };
+}

--- a/apps/api/src/EduConnect.Api/Migrations/20260421162559_AddHomeworkSubmissions.Designer.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421162559_AddHomeworkSubmissions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EduConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduConnect.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421162559_AddHomeworkSubmissions")]
+    partial class AddHomeworkSubmissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/EduConnect.Api/Migrations/20260421162559_AddHomeworkSubmissions.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260421162559_AddHomeworkSubmissions.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EduConnect.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHomeworkSubmissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "homework_submissions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    school_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    homework_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    student_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    body_text = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    submitted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()"),
+                    grade = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    feedback = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    graded_by_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    graded_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()"),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_homework_submissions", x => x.id);
+                    table.CheckConstraint("chk_homework_submission_status", "status IN ('Submitted', 'Late', 'Graded', 'Returned')");
+                    table.ForeignKey(
+                        name: "fk_homework_submissions_homework_homework_id",
+                        column: x => x.homework_id,
+                        principalTable: "homework",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_homework_submissions_schools_school_id",
+                        column: x => x.school_id,
+                        principalTable: "schools",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_homework_submissions_students_student_id",
+                        column: x => x.student_id,
+                        principalTable: "students",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_homework_submissions_users_graded_by_id",
+                        column: x => x.graded_by_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_homework_submissions_graded_by_id",
+                table: "homework_submissions",
+                column: "graded_by_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_homework_submissions_homework_id",
+                table: "homework_submissions",
+                column: "homework_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_homework_submissions_school_id",
+                table: "homework_submissions",
+                column: "school_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_homework_submissions_student_id",
+                table: "homework_submissions",
+                column: "student_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_homework_submissions_homework_student",
+                table: "homework_submissions",
+                columns: new[] { "homework_id", "student_id" },
+                unique: true);
+
+            // RLS (Phase 4 pattern). New tenanted table gets isolation from
+            // day one — migration itself runs with no tenant set so the
+            // NULL-bypass branch keeps DDL unaffected.
+            migrationBuilder.Sql("ALTER TABLE homework_submissions ENABLE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE homework_submissions FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql(@"
+                CREATE POLICY tenant_isolation ON homework_submissions
+                USING (current_app_school_id() IS NULL OR school_id = current_app_school_id())
+                WITH CHECK (current_app_school_id() IS NULL OR school_id = current_app_school_id());
+            ");
+
+            // Widen attachments.entity_type to allow attaching files to a
+            // submission. Existing 'homework' / 'notice' rows are unaffected.
+            migrationBuilder.Sql(@"
+                ALTER TABLE attachments DROP CONSTRAINT IF EXISTS chk_attachment_entity_type;
+                ALTER TABLE attachments ADD CONSTRAINT chk_attachment_entity_type
+                  CHECK (entity_type IS NULL OR entity_type IN ('homework', 'notice', 'homework_submission'));
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Restore attachments check to the pre-phase-6 set before dropping
+            // the new table.
+            migrationBuilder.Sql(@"
+                ALTER TABLE attachments DROP CONSTRAINT IF EXISTS chk_attachment_entity_type;
+                ALTER TABLE attachments ADD CONSTRAINT chk_attachment_entity_type
+                  CHECK (entity_type IS NULL OR entity_type IN ('homework', 'notice'));
+            ");
+
+            migrationBuilder.Sql("DROP POLICY IF EXISTS tenant_isolation ON homework_submissions;");
+            migrationBuilder.Sql("ALTER TABLE homework_submissions NO FORCE ROW LEVEL SECURITY;");
+            migrationBuilder.Sql("ALTER TABLE homework_submissions DISABLE ROW LEVEL SECURITY;");
+
+            migrationBuilder.DropTable(
+                name: "homework_submissions");
+        }
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkSubmissionFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkSubmissionFlowTests.cs
@@ -1,0 +1,372 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Features.HomeworkSubmissions.GetMySubmissions;
+using EduConnect.Api.Features.HomeworkSubmissions.GradeHomeworkSubmission;
+using EduConnect.Api.Features.HomeworkSubmissions.SubmitHomework;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+public class HomeworkSubmissionFlowTests
+{
+    private readonly Guid _schoolId = Guid.NewGuid();
+    private readonly Guid _classId = Guid.NewGuid();
+    private readonly Guid _studentId = Guid.NewGuid();
+    private readonly Guid _parentId = Guid.NewGuid();
+    private readonly Guid _teacherId = Guid.NewGuid();
+
+    [Fact]
+    public async Task Submit_happy_path_creates_Submitted_record()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        var parent = CurrentUser("Parent", _parentId);
+        await using var context = new AppDbContext(options, parent);
+        var handler = new SubmitHomeworkCommandHandler(context, parent, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+
+        var result = await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "My answer", null),
+            CancellationToken.None);
+
+        result.Status.Should().Be(HomeworkSubmissionStatus.Submitted);
+
+        var saved = await context.HomeworkSubmissions.SingleAsync();
+        saved.StudentId.Should().Be(_studentId);
+        saved.HomeworkId.Should().Be(homeworkId);
+        saved.BodyText.Should().Be("My answer");
+    }
+
+    [Fact]
+    public async Task Submit_after_due_date_records_Late_status()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: -1);
+
+        var parent = CurrentUser("Parent", _parentId);
+        await using var context = new AppDbContext(options, parent);
+        var handler = new SubmitHomeworkCommandHandler(context, parent, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+
+        var result = await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "Late but here", null),
+            CancellationToken.None);
+
+        result.Status.Should().Be(HomeworkSubmissionStatus.Late);
+    }
+
+    [Fact]
+    public async Task Submit_as_unlinked_parent_is_forbidden()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        var strangerParentId = Guid.NewGuid();
+        var stranger = CurrentUser("Parent", strangerParentId);
+        await using var context = new AppDbContext(options, stranger);
+        // Parent exists as a user but has no ParentStudentLink.
+        context.Users.Add(new UserEntity
+        {
+            Id = strangerParentId,
+            SchoolId = _schoolId,
+            Phone = "09000001111",
+            Name = "Unrelated Parent",
+            Role = "Parent",
+        });
+        await context.SaveChangesAsync();
+
+        var handler = new SubmitHomeworkCommandHandler(context, stranger, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+
+        var act = async () => await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "hack", null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("You can only submit homework for your own child.");
+    }
+
+    [Fact]
+    public async Task Submit_by_non_parent_role_is_forbidden()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        var teacher = CurrentUser("Teacher", _teacherId);
+        await using var context = new AppDbContext(options, teacher);
+        var handler = new SubmitHomeworkCommandHandler(context, teacher, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+
+        var act = async () => await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "teacher tried to submit", null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("Only parents can submit homework on behalf of a student.");
+    }
+
+    [Fact]
+    public async Task Submit_twice_upserts_and_keeps_single_row()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        var parent = CurrentUser("Parent", _parentId);
+        await using var context = new AppDbContext(options, parent);
+        var handler = new SubmitHomeworkCommandHandler(context, parent, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+
+        await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "first", null),
+            CancellationToken.None);
+        var second = await handler.Handle(
+            new SubmitHomeworkCommand(homeworkId, _studentId, "second", null),
+            CancellationToken.None);
+
+        (await context.HomeworkSubmissions.CountAsync()).Should().Be(1);
+        var row = await context.HomeworkSubmissions.SingleAsync();
+        row.BodyText.Should().Be("second");
+        row.Id.Should().Be(second.SubmissionId);
+    }
+
+    [Fact]
+    public async Task Teacher_who_authored_homework_can_grade()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        // Seed a submission first via the parent handler.
+        var parent = CurrentUser("Parent", _parentId);
+        await using (var context = new AppDbContext(options, parent))
+        {
+            var submitHandler = new SubmitHomeworkCommandHandler(context, parent, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+            await submitHandler.Handle(
+                new SubmitHomeworkCommand(homeworkId, _studentId, "done", null),
+                CancellationToken.None);
+        }
+
+        Guid submissionId;
+        await using (var readCtx = new AppDbContext(options, parent))
+        {
+            submissionId = (await readCtx.HomeworkSubmissions.SingleAsync()).Id;
+        }
+
+        var teacher = CurrentUser("Teacher", _teacherId);
+        await using var gradeCtx = new AppDbContext(options, teacher);
+        var gradeHandler = new GradeHomeworkSubmissionCommandHandler(
+            gradeCtx, teacher, NullLogger<GradeHomeworkSubmissionCommandHandler>.Instance);
+
+        var result = await gradeHandler.Handle(
+            new GradeHomeworkSubmissionCommand(submissionId, "A", "Good work"),
+            CancellationToken.None);
+
+        result.Grade.Should().Be("A");
+        var row = await gradeCtx.HomeworkSubmissions.SingleAsync();
+        row.Status.Should().Be(HomeworkSubmissionStatus.Graded);
+        row.GradedById.Should().Be(_teacherId);
+    }
+
+    [Fact]
+    public async Task Teacher_not_assigned_and_not_author_cannot_grade()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        var parent = CurrentUser("Parent", _parentId);
+        await using (var context = new AppDbContext(options, parent))
+        {
+            var submit = new SubmitHomeworkCommandHandler(context, parent, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+            await submit.Handle(new SubmitHomeworkCommand(homeworkId, _studentId, "done", null), CancellationToken.None);
+        }
+
+        Guid submissionId;
+        await using (var read = new AppDbContext(options, parent))
+        {
+            submissionId = (await read.HomeworkSubmissions.SingleAsync()).Id;
+        }
+
+        // A different teacher who isn't the author and has no class assignment.
+        var otherTeacherId = Guid.NewGuid();
+        await using (var ctx = new AppDbContext(options, parent))
+        {
+            ctx.Users.Add(new UserEntity
+            {
+                Id = otherTeacherId,
+                SchoolId = _schoolId,
+                Phone = "09000002222",
+                Name = "Other Teacher",
+                Role = "Teacher",
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var otherTeacher = CurrentUser("Teacher", otherTeacherId);
+        await using var gradeCtx = new AppDbContext(options, otherTeacher);
+        var gradeHandler = new GradeHomeworkSubmissionCommandHandler(
+            gradeCtx, otherTeacher, NullLogger<GradeHomeworkSubmissionCommandHandler>.Instance);
+
+        var act = async () => await gradeHandler.Handle(
+            new GradeHomeworkSubmissionCommand(submissionId, "A", null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("You are not assigned to this homework's class.");
+    }
+
+    [Fact]
+    public async Task GetMySubmissions_returns_only_parents_own_childrens_rows()
+    {
+        var options = CreateOptions();
+        var homeworkId = await SeedStandardFixtureAsync(options, dueInDays: 3);
+
+        // Seed a second student + parent in the same school. Parent A's query
+        // must not leak Parent B's child's submission.
+        var otherParentId = Guid.NewGuid();
+        var otherStudentId = Guid.NewGuid();
+
+        await using (var ctx = new AppDbContext(options, CurrentUser("Parent", _parentId)))
+        {
+            ctx.Users.Add(new UserEntity
+            {
+                Id = otherParentId,
+                SchoolId = _schoolId,
+                Phone = "09000003333",
+                Name = "Other Parent",
+                Role = "Parent",
+            });
+            ctx.Students.Add(new StudentEntity
+            {
+                Id = otherStudentId,
+                SchoolId = _schoolId,
+                ClassId = _classId,
+                Name = "Other Student",
+                RollNumber = "002",
+                IsActive = true,
+            });
+            ctx.ParentStudentLinks.Add(new ParentStudentLinkEntity
+            {
+                Id = Guid.NewGuid(),
+                SchoolId = _schoolId,
+                ParentId = otherParentId,
+                StudentId = otherStudentId,
+                Relationship = "parent",
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        // Both parents submit.
+        var parentA = CurrentUser("Parent", _parentId);
+        await using (var ctx = new AppDbContext(options, parentA))
+        {
+            var submit = new SubmitHomeworkCommandHandler(ctx, parentA, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+            await submit.Handle(new SubmitHomeworkCommand(homeworkId, _studentId, "A-answer", null), CancellationToken.None);
+        }
+        var parentB = CurrentUser("Parent", otherParentId);
+        await using (var ctx = new AppDbContext(options, parentB))
+        {
+            var submit = new SubmitHomeworkCommandHandler(ctx, parentB, NullLogger<SubmitHomeworkCommandHandler>.Instance);
+            await submit.Handle(new SubmitHomeworkCommand(homeworkId, otherStudentId, "B-answer", null), CancellationToken.None);
+        }
+
+        await using var readCtx = new AppDbContext(options, parentA);
+        var handler = new GetMySubmissionsQueryHandler(readCtx, parentA);
+        var rows = await handler.Handle(new GetMySubmissionsQuery(null), CancellationToken.None);
+
+        rows.Should().ContainSingle();
+        rows[0].StudentId.Should().Be(_studentId);
+        rows[0].BodyText.Should().Be("A-answer");
+    }
+
+    // ── fixture helpers ─────────────────────────────────────────────────
+
+    private static DbContextOptions<AppDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private CurrentUserService CurrentUser(string role, Guid userId) => new()
+    {
+        SchoolId = _schoolId,
+        UserId = userId,
+        Role = role,
+        Name = role,
+    };
+
+    private async Task<Guid> SeedStandardFixtureAsync(
+        DbContextOptions<AppDbContext> options,
+        int dueInDays)
+    {
+        var homeworkId = Guid.NewGuid();
+
+        await using var ctx = new AppDbContext(options, new CurrentUserService());
+
+        ctx.Schools.Add(new SchoolEntity
+        {
+            Id = _schoolId,
+            Name = "School",
+            Code = "S1",
+            Address = "",
+            ContactPhone = "",
+            ContactEmail = "",
+        });
+        ctx.Classes.Add(new ClassEntity
+        {
+            Id = _classId,
+            SchoolId = _schoolId,
+            Name = "6",
+            Section = "A",
+            AcademicYear = "2026",
+        });
+        ctx.Users.Add(new UserEntity
+        {
+            Id = _parentId,
+            SchoolId = _schoolId,
+            Phone = "09000000001",
+            Name = "Parent",
+            Role = "Parent",
+        });
+        ctx.Users.Add(new UserEntity
+        {
+            Id = _teacherId,
+            SchoolId = _schoolId,
+            Phone = "09000000002",
+            Name = "Teacher",
+            Role = "Teacher",
+        });
+        ctx.Students.Add(new StudentEntity
+        {
+            Id = _studentId,
+            SchoolId = _schoolId,
+            ClassId = _classId,
+            Name = "Student",
+            RollNumber = "001",
+            IsActive = true,
+        });
+        ctx.ParentStudentLinks.Add(new ParentStudentLinkEntity
+        {
+            Id = Guid.NewGuid(),
+            SchoolId = _schoolId,
+            ParentId = _parentId,
+            StudentId = _studentId,
+            Relationship = "parent",
+        });
+        ctx.Homeworks.Add(new HomeworkEntity
+        {
+            Id = homeworkId,
+            SchoolId = _schoolId,
+            ClassId = _classId,
+            Subject = "Math",
+            Title = "HW",
+            Description = "",
+            AssignedById = _teacherId,
+            DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(dueInDays)),
+            Status = "Published",
+        });
+
+        await ctx.SaveChangesAsync();
+        return homeworkId;
+    }
+}


### PR DESCRIPTION
…w (Phase 6)

Introduces the long-missing submission half of the homework lifecycle. Parents can now submit work on behalf of their child; teachers and admins can grade it; parents see graded feedback for their children only. Existing teacher→admin approval flow ("submit for publish") is untouched — it shares the URL verb "submit" but lives on a different path, so no rename was required to clear semantic space.

Schema (apps/api, migration 20260421162559_AddHomeworkSubmissions):
- New homework_submissions table. One row per (homework, student) via a unique index; FKs cascade from homework / student / school. Status enforced by check constraint: Submitted / Late / Graded / Returned. (Returned is reserved for a follow-up "teacher asks for redo" flow; not exposed by any handler yet.)
- Phase 4 pattern applied on day one: ENABLE + FORCE ROW LEVEL SECURITY plus the uniform tenant_isolation policy.
- attachments.entity_type check constraint widened to accept 'homework_submission' so photos of handwritten work can be linked to a submission via the existing attachment pipeline (which now also carries them through the Phase 5 virus scanner).

Feature slices (Features/HomeworkSubmissions/):
- SubmitHomework (POST /api/homework/{id}/submissions): Parent-only. Verifies ParentStudentLinks, matches student's class to the homework's class, tags Late when past DueDate, and upserts so re-submission from the same parent updates the same row. Blocks resubmission after a teacher has graded (pending a proper Return flow). Optionally links attachments uploaded by the same parent.
- GradeHomeworkSubmission (PUT /api/homework-submissions/{id}/grade): Teacher or Admin. Teachers can only grade submissions for homework they authored or for a class they're assigned to. Sets Status=Graded.
- GetSubmissionsByHomework (GET /api/homework/{id}/submissions): Teacher/Admin view of every submission on a given homework.
- GetMySubmissions (GET /api/homework-submissions/mine): Parent view. Optional ?studentId=... narrows to one child; without it, returns every submission for every child linked to the parent.

Routes registered under a new MapHomeworkSubmissionEndpoints group in EndpointRouteBuilderExtensions.

Tests (HomeworkSubmissionFlowTests, 8 new):
- Parent submit happy path → Status=Submitted.
- Submit after due date → Status=Late.
- Parent without a ParentStudentLink is blocked with ForbiddenException.
- Non-parent role blocked.
- Re-submit from same parent keeps a single row (upsert).
- Teacher who authored the homework can grade.
- Teacher not assigned + not author is blocked.
- Parent query returns only their own children's submissions.

Full suite: 96 passing (baseline 88 + 8 new) + 3 skipped RLS tests, same 2 unrelated pre-existing AdminOnboarding failures.

Deferred follow-ups (documented in audit Phase 6 scope):
- Return-for-redo flow (Status=Returned transitions + resubmission).
- Late auto-transition job for submissions that never arrive.
- Notifications on submit/grade.
- Frontend surfaces (student detail tab, teacher submissions tab, parent view).
- Rename of the teacher→admin approval flow's UI labels (the API route /homework/{id}/submit is an existing verb on a path that doesn't collide with the new /submissions collection).

Rollback: revert this commit, then
"dotnet ef database update <previous migration>". Down path restores the attachments check constraint and drops the homework_submissions table together with its RLS policy.