### PR TITLE
feat(web): move login + logout to Server Actions (Phase 7 wave 1)

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -3,29 +3,28 @@
 import * as React from "react";
 import Link from "next/link";
 import { Eye, EyeOff, KeyRound, UserRound } from "lucide-react";
+import { useActionState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
-import { ApiError, apiPost } from "@/lib/api-client";
-import { API_ENDPOINTS, defaultRouteByRole } from "@/lib/constants";
+import { defaultRouteByRole } from "@/lib/constants";
 import {
-  isValidJapanPhone,
   JAPAN_PHONE_COUNTRY_CODE,
   JAPAN_PHONE_COUNTRY_LABEL,
   JAPAN_PHONE_LOCAL_DIGITS,
-  JAPAN_PHONE_VALIDATION_MESSAGE,
   normalizeJapanPhoneInput,
 } from "@/lib/phone";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBanner } from "@/components/shared/status-banner";
-
-interface LoginResponse {
-  accessToken: string;
-  expiresIn?: number;
-  mustChangePassword?: boolean;
-}
+import {
+  loginAction,
+  type ActionResult,
+  type LoginSuccessData,
+} from "@/lib/actions/auth-actions";
 
 type LoginMode = "parent" | "staff";
+
+const initialState: ActionResult<LoginSuccessData> | null = null;
 
 export function LoginForm(): React.ReactElement {
   const router = useRouter();
@@ -34,13 +33,14 @@ export function LoginForm(): React.ReactElement {
   const [phone, setPhone] = React.useState<string>("");
   const [pin, setPin] = React.useState<string>("");
   const [password, setPassword] = React.useState<string>("");
-  const [error, setError] = React.useState<string>("");
-  const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [showPassword, setShowPassword] = React.useState<boolean>(false);
   const phoneRef = React.useRef<HTMLInputElement | null>(null);
   const secureFieldClassName =
     "focus-ring flex min-h-12 w-full rounded-[20px] border border-input/90 bg-card/85 px-4 py-3 text-sm text-foreground shadow-[0_12px_30px_-28px_rgba(15,40,69,0.38)] ring-offset-background backdrop-blur-sm placeholder:text-muted-foreground/90 focus-visible:border-primary/40 disabled:cursor-not-allowed disabled:opacity-60";
 
+  const [state, formAction, isPending] = useActionState(loginAction, initialState);
+
+  // Redirect an already-authenticated visitor to their dashboard.
   React.useEffect(() => {
     if (isAuthLoading || !user) return;
     if (user.mustChangePassword) {
@@ -50,22 +50,23 @@ export function LoginForm(): React.ReactElement {
     router.replace(defaultRouteByRole[user.role]);
   }, [isAuthLoading, router, user]);
 
+  // Promote a successful server-action login to in-memory token state so
+  // subsequent api-client requests carry the bearer.
+  React.useEffect(() => {
+    if (state?.ok) {
+      login(state.data.accessToken, state.data.expiresIn);
+    }
+  }, [state, login]);
+
   const handlePhoneChange = (value: string): void => {
     setPhone(normalizeJapanPhoneInput(value));
-    setError("");
   };
 
   const handlePinChange = (value: string): void => {
     const cleaned = value.replace(/\D/g, "");
     if (cleaned.length <= 6) {
       setPin(cleaned);
-      setError("");
     }
-  };
-
-  const handlePasswordChange = (value: string): void => {
-    setPassword(value);
-    setError("");
   };
 
   const handleModeSwitch = (newMode: LoginMode): void => {
@@ -73,55 +74,13 @@ export function LoginForm(): React.ReactElement {
     setPhone("");
     setPin("");
     setPassword("");
-    setError("");
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    e.preventDefault();
-    setError("");
-
-    if (mode === "parent") {
-      if (!isValidJapanPhone(phone)) {
-        setError(JAPAN_PHONE_VALIDATION_MESSAGE);
-        return;
-      }
-      if (pin.length < 4 || pin.length > 6) {
-        setError("PIN must be 4-6 digits");
-        return;
-      }
-    } else {
-      if (!isValidJapanPhone(phone)) {
-        setError(JAPAN_PHONE_VALIDATION_MESSAGE);
-        return;
-      }
-      if (!password) {
-        setError("Password is required");
-        return;
-      }
-    }
-
-    setIsLoading(true);
-
-    try {
-      const endpoint =
-        mode === "parent" ? API_ENDPOINTS.loginParent : API_ENDPOINTS.login;
-      const payload =
-        mode === "parent"
-          ? { phone, pin }
-          : { phone, password };
-
-      const response = await apiPost<LoginResponse>(endpoint, payload);
-      login(response.accessToken, response.expiresIn);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setError(err.message || "Login failed. Please try again.");
-      } else {
-        setError("An unexpected error occurred. Please try again.");
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const formError = state && !state.ok ? state.formError : undefined;
+  const fieldErrors = state && !state.ok ? state.fieldErrors ?? {} : {};
+  const phoneError = fieldErrors.phone;
+  const passwordError = fieldErrors.password;
+  const pinError = fieldErrors.pin;
 
   return (
     <div className="space-y-6">
@@ -143,7 +102,7 @@ export function LoginForm(): React.ReactElement {
               role="tab"
               aria-selected={mode === "parent"}
               onClick={() => handleModeSwitch("parent")}
-              disabled={isLoading || isAuthLoading}
+              disabled={isPending || isAuthLoading}
               className={[
                 "focus-ring tap-target inline-flex items-center justify-center gap-2 rounded-[18px] px-3 text-sm font-semibold transition",
                 mode === "parent"
@@ -159,7 +118,7 @@ export function LoginForm(): React.ReactElement {
               role="tab"
               aria-selected={mode === "staff"}
               onClick={() => handleModeSwitch("staff")}
-              disabled={isLoading || isAuthLoading}
+              disabled={isPending || isAuthLoading}
               className={[
                 "focus-ring tap-target inline-flex items-center justify-center gap-2 rounded-[18px] px-3 text-sm font-semibold transition",
                 mode === "staff"
@@ -179,7 +138,9 @@ export function LoginForm(): React.ReactElement {
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form action={formAction} className="space-y-4">
+        <input type="hidden" name="mode" value={mode} />
+
         <div className="space-y-2">
           <label htmlFor="phone" className="block text-sm font-medium text-foreground">
             Phone number
@@ -197,13 +158,14 @@ export function LoginForm(): React.ReactElement {
             </span>
             <input
               id="phone"
+              name="phone"
               type="tel"
               placeholder="Enter 11-digit number"
               value={phone}
               onChange={(e): void => handlePhoneChange(e.target.value)}
-              disabled={isLoading || isAuthLoading}
-              aria-invalid={!!error}
-              aria-describedby={error ? "form-error" : mode === "parent" ? "parent-phone-hint" : "staff-phone-hint"}
+              disabled={isPending || isAuthLoading}
+              aria-invalid={!!(formError || phoneError)}
+              aria-describedby={phoneError ? "phone-error" : mode === "parent" ? "parent-phone-hint" : "staff-phone-hint"}
               maxLength={JAPAN_PHONE_LOCAL_DIGITS}
               inputMode="numeric"
               pattern="[0-9]*"
@@ -213,14 +175,18 @@ export function LoginForm(): React.ReactElement {
               className="w-full flex-1 bg-transparent py-3 text-sm font-semibold text-foreground outline-none placeholder:font-medium placeholder:text-muted-foreground/90"
             />
           </div>
-          <p
-            id={mode === "parent" ? "parent-phone-hint" : "staff-phone-hint"}
-            className="text-xs text-muted-foreground"
-          >
-            {mode === "parent"
-              ? "Use the phone number linked to your parent account."
-              : "Use the 11-digit number registered with the school."}
-          </p>
+          {phoneError ? (
+            <p id="phone-error" className="text-xs text-destructive">{phoneError}</p>
+          ) : (
+            <p
+              id={mode === "parent" ? "parent-phone-hint" : "staff-phone-hint"}
+              className="text-xs text-muted-foreground"
+            >
+              {mode === "parent"
+                ? "Use the phone number linked to your parent account."
+                : "Use the 11-digit number registered with the school."}
+            </p>
+          )}
         </div>
 
         {mode === "parent" ? (
@@ -230,20 +196,25 @@ export function LoginForm(): React.ReactElement {
             </label>
             <input
               id="pin"
+              name="pin"
               type="password"
               inputMode="numeric"
               placeholder="••••"
               value={pin}
               onChange={(e): void => handlePinChange(e.target.value)}
-              disabled={isLoading || isAuthLoading}
-              aria-invalid={!!error}
-              aria-describedby={error ? "form-error" : undefined}
+              disabled={isPending || isAuthLoading}
+              aria-invalid={!!(formError || pinError)}
+              aria-describedby={pinError ? "pin-error" : undefined}
               maxLength={6}
               pattern="[0-9]*"
               autoComplete="current-password"
               className={secureFieldClassName}
             />
-            <p className="text-xs text-muted-foreground">4–6 digits</p>
+            {pinError ? (
+              <p id="pin-error" className="text-xs text-destructive">{pinError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">4–6 digits</p>
+            )}
           </div>
         ) : (
           <div className="space-y-2">
@@ -256,20 +227,21 @@ export function LoginForm(): React.ReactElement {
             <div className="relative">
               <input
                 id="password"
+                name="password"
                 type={showPassword ? "text" : "password"}
                 placeholder="••••••••"
                 value={password}
-                onChange={(e): void => handlePasswordChange(e.target.value)}
-                disabled={isLoading || isAuthLoading}
-                aria-invalid={!!error}
-                aria-describedby={error ? "form-error" : "staff-password-hint"}
+                onChange={(e): void => setPassword(e.target.value)}
+                disabled={isPending || isAuthLoading}
+                aria-invalid={!!(formError || passwordError)}
+                aria-describedby={passwordError ? "password-error" : "staff-password-hint"}
                 autoComplete="current-password"
                 className={secureFieldClassName}
               />
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
-                disabled={isLoading || isAuthLoading}
+                disabled={isPending || isAuthLoading}
                 className="focus-ring tap-target absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center rounded-full px-3 text-sm font-semibold text-muted-foreground hover:bg-card/60 hover:text-foreground disabled:opacity-50"
                 aria-label={showPassword ? "Hide password" : "Show password"}
               >
@@ -286,25 +258,29 @@ export function LoginForm(): React.ReactElement {
                 )}
               </button>
             </div>
-            <p id="staff-password-hint" className="text-xs text-muted-foreground">
-              Use your staff account password.
-            </p>
+            {passwordError ? (
+              <p id="password-error" className="text-xs text-destructive">{passwordError}</p>
+            ) : (
+              <p id="staff-password-hint" className="text-xs text-muted-foreground">
+                Use your staff account password.
+              </p>
+            )}
           </div>
         )}
 
-        {error && (
+        {formError && (
           <StatusBanner id="form-error" variant="error">
-            {error}
+            {formError}
           </StatusBanner>
         )}
 
         <Button
           type="submit"
           className="h-12 min-h-12 w-full"
-          disabled={isLoading || isAuthLoading}
+          disabled={isPending || isAuthLoading}
           size="default"
         >
-          {isLoading ? (
+          {isPending ? (
             <>
               <Spinner size="sm" />
               <span>Logging in...</span>

--- a/apps/web/docs/server-actions.md
+++ b/apps/web/docs/server-actions.md
@@ -1,0 +1,160 @@
+# Server Actions migration — pattern for Phase 7 waves 2–5
+
+Wave 1 (auth) is merged. This document is the template every subsequent
+wave follows so reviewers see a repeating shape across
+homework / attendance / notices / user-admin PRs.
+
+## Why Server Actions
+
+- **CSRF** — Next 15 encrypts the action payload so cross-origin replay is
+  rejected by the framework itself.
+- **Progressive enhancement** — forms work without JS when the action
+  runs on the Next.js server.
+- **Less hand-rolled loading / error glue** — `useActionState` +
+  `useFormStatus` replace the `isSubmitting` / `error` state every form
+  was previously re-implementing.
+- **Stack alignment** — the FBT stack doc declares Server Actions as the
+  mutation path.
+
+## The per-action shape
+
+Every action:
+
+```ts
+"use server";
+
+import { z } from "zod";
+import { callBackend } from "@/lib/actions/backend";
+
+const schema = z.object({ /* same schema as the form's client-side parse */ });
+
+type Input = z.infer<typeof schema>;
+type Success = { /* DTO */ };
+
+export type Result =
+  | { ok: true; data: Success }
+  | { ok: false; fieldErrors?: Partial<Record<keyof Input, string>>; formError?: string };
+
+export async function createHomeworkAction(
+  _prev: Result | null,
+  formData: FormData,
+): Promise<Result> {
+  const parsed = schema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) { /* map issues to fieldErrors */ }
+
+  const result = await callBackend<Success>("/api/homework", {
+    method: "POST",
+    body: JSON.stringify(parsed.data),
+  });
+  if (!result.ok) { /* map backend errors */ }
+  return { ok: true, data: result.data };
+}
+```
+
+Forms use `useActionState`:
+
+```tsx
+"use client";
+const [state, formAction, isPending] = useActionState(createHomeworkAction, null);
+
+return (
+  <form action={formAction}>
+    {/* fields */}
+    <button disabled={isPending}>{isPending ? "Saving…" : "Create"}</button>
+    {state && !state.ok && state.formError && <Error>{state.formError}</Error>}
+  </form>
+);
+```
+
+Rules:
+- Input is parsed by the same Zod schema the client used to render
+  inline validation hints. Keep both under `lib/validation/*`.
+- The return type is **always** the `Result` discriminated union. No
+  throwing for expected errors; only unexpected exceptions bubble to
+  the error boundary.
+- Do not call `redirect()` on error paths. Return the error shape and
+  let the form render it.
+
+## Auth token flow in a Server Action
+
+The in-memory `tokenStore` (Phase 3) lives in the browser and is
+inaccessible from server code. Each action that hits the .NET API calls
+`mintBackendAccessToken()` from `lib/actions/auth-actions.ts` to mint a
+per-request bearer using the browser's HttpOnly refresh cookie, then
+forwards the rotated cookie back via `cookies().set()`. The call helper
+(forthcoming, to land in Wave 2) wraps this:
+
+```ts
+// lib/actions/backend.ts  -- scaffold that Wave 2 will create
+"use server";
+
+import { mintBackendAccessToken } from "@/lib/actions/auth-actions";
+
+export async function callBackend<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<{ ok: true; data: T } | { ok: false; status: number; problem?: unknown }> {
+  const token = await mintBackendAccessToken();
+  if (!token) return { ok: false, status: 401 };
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    const problem = await res.json().catch(() => undefined);
+    return { ok: false, status: res.status, problem };
+  }
+
+  return { ok: true, data: res.status === 204 ? (undefined as T) : ((await res.json()) as T) };
+}
+```
+
+## Migration waves and order
+
+Each wave is **one branch, one PR**.
+
+| Wave | Domain | Scope |
+|------|--------|-------|
+| 1    | Auth   | login, logout + shared `mintBackendAccessToken` helper. **Done.** |
+| 2    | Homework | create, update, submit-for-approval, approve, reject. Also lands the `callBackend` helper. |
+| 3    | Attendance | mark, bulk mark, edit, leave apply/approve/reject/cancel. |
+| 4    | Notices | create, publish, pin, delete. |
+| 5    | User CRUD | create-teacher, link-parent-to-student, enroll-student, deactivate-student. |
+
+Read endpoints stay as-is — no dashboard pages need to move off the
+browser-side `api-client`. Server Actions are mutation-only.
+
+## Known limitations (addressed in later waves)
+
+### Concurrent mint → refresh-token reuse false positive
+
+Two Server Actions that fire within the same tick both present the
+same refresh cookie to `/api/auth/refresh`. The Phase 3 reuse-detection
+path revokes the family and logs the user out.
+
+Current status: NOT HIT in practice because waves 2-5 haven't landed
+yet. When a wave starts triggering it, the fix is a backend-side
+non-rotating mint (e.g. a query parameter that mints a fresh access
+token without revoking the presented refresh token). That change
+belongs to Wave 2 so it ships alongside the first action that needs it.
+
+### Rate limiter keying
+
+The .NET rate limiter partitions on `userId` claim (see `Program.cs`).
+The Server Action's bearer carries the same claim so this continues to
+work, but the rate limit now accounts for the per-action mint call
+(one extra `/auth/refresh` per mutation). Re-check partition sizing
+when Wave 3 (attendance bulk mark) ships.
+
+### Reads stay on the client
+
+`api-client.ts` continues to serve every GET. Waves 2-5 only move
+mutations. This means each page still bootstraps auth via the existing
+in-memory `tokenStore` + single-flight refresh from Phase 3. The two
+systems coexist — actions handle mutations, client handles reads.

--- a/apps/web/lib/actions/auth-actions.ts
+++ b/apps/web/lib/actions/auth-actions.ts
@@ -1,0 +1,230 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { loginSchema, type LoginInput } from "@/lib/validation/login";
+
+const REFRESH_COOKIE_NAME = "refresh_token";
+
+export interface LoginSuccessData {
+  accessToken: string;
+  expiresIn: number;
+  mustChangePassword: boolean;
+}
+
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; fieldErrors?: Partial<Record<string, string>>; formError?: string };
+
+function apiBase(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL is not defined");
+  }
+  return baseUrl;
+}
+
+/**
+ * Parses a single Set-Cookie header value into a minimal attribute map.
+ * We only care about name/value and Expires — HttpOnly, Secure, SameSite
+ * and Path are re-applied as app invariants via cookies().set() rather
+ * than trusted from the upstream header.
+ */
+function parseSetCookie(raw: string): { name: string; value: string; expires?: Date } | null {
+  const [pair, ...attrs] = raw.split(";").map((s) => s.trim());
+  if (!pair) return null;
+  const eq = pair.indexOf("=");
+  if (eq <= 0) return null;
+  const name = pair.slice(0, eq);
+  const value = pair.slice(eq + 1);
+
+  let expires: Date | undefined;
+  for (const attr of attrs) {
+    const parts = attr.split("=", 2).map((s) => s?.trim() ?? "");
+    const k = parts[0] ?? "";
+    const v = parts[1] ?? "";
+    if (k.toLowerCase() === "expires" && v) {
+      const d = new Date(v);
+      if (!Number.isNaN(d.getTime())) expires = d;
+    }
+  }
+
+  return { name, value, expires };
+}
+
+async function proxyRefreshCookie(response: Response): Promise<void> {
+  const setCookies = response.headers.getSetCookie();
+  for (const entry of setCookies) {
+    const parsed = parseSetCookie(entry);
+    if (!parsed || parsed.name !== REFRESH_COOKIE_NAME) continue;
+
+    const cookieStore = await cookies();
+    cookieStore.set({
+      name: parsed.name,
+      value: parsed.value,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      path: "/",
+      expires: parsed.expires,
+    });
+  }
+}
+
+async function forwardedRefreshCookieHeader(): Promise<string> {
+  const cookieStore = await cookies();
+  const refresh = cookieStore.get(REFRESH_COOKIE_NAME);
+  return refresh ? `${REFRESH_COOKIE_NAME}=${refresh.value}` : "";
+}
+
+function mapBackendValidationErrors(
+  body: unknown,
+): { fieldErrors: Record<string, string>; formError?: string } {
+  const errors: Record<string, string> = {};
+  let formError: string | undefined;
+
+  if (typeof body === "object" && body !== null) {
+    const b = body as Record<string, unknown>;
+    if (typeof b.detail === "string") formError = b.detail;
+    else if (typeof b.title === "string") formError = b.title;
+
+    if (b.errors && typeof b.errors === "object") {
+      for (const [key, value] of Object.entries(b.errors as Record<string, unknown>)) {
+        if (Array.isArray(value) && typeof value[0] === "string") {
+          errors[key.toLowerCase()] = value[0] as string;
+        }
+      }
+    }
+  }
+
+  return { fieldErrors: errors, formError };
+}
+
+export async function loginAction(
+  _prev: ActionResult<LoginSuccessData> | null,
+  formData: FormData,
+): Promise<ActionResult<LoginSuccessData>> {
+  const raw = {
+    mode: formData.get("mode"),
+    phone: formData.get("phone"),
+    password: formData.get("password") ?? undefined,
+    pin: formData.get("pin") ?? undefined,
+  };
+
+  const parsed = loginSchema.safeParse(raw);
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0];
+      if (typeof key === "string" && !fieldErrors[key]) {
+        fieldErrors[key] = issue.message;
+      }
+    }
+    return { ok: false, fieldErrors };
+  }
+
+  const input: LoginInput = parsed.data;
+  const endpoint =
+    input.mode === "parent" ? "/api/auth/login-parent" : "/api/auth/login";
+  const body =
+    input.mode === "parent"
+      ? { phone: input.phone, pin: input.pin }
+      : { phone: input.phone, password: input.password };
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBase()}${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      // No credentials: this fetch runs on the Next server; cookies are
+      // handled explicitly by proxyRefreshCookie() below.
+    });
+  } catch {
+    return { ok: false, formError: "Could not reach the server. Please try again." };
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null);
+    const mapped = mapBackendValidationErrors(errorBody);
+    return {
+      ok: false,
+      fieldErrors: Object.keys(mapped.fieldErrors).length ? mapped.fieldErrors : undefined,
+      formError:
+        mapped.formError ??
+        (response.status === 401
+          ? "Invalid phone or password."
+          : "Login failed. Please try again."),
+    };
+  }
+
+  await proxyRefreshCookie(response);
+
+  const data = (await response.json()) as LoginSuccessData;
+  return { ok: true, data };
+}
+
+/**
+ * Mints a short-lived backend access token inside a Server Action context
+ * by calling /api/auth/refresh with the browser's HttpOnly refresh cookie.
+ * Proxies the rotated refresh cookie back to the browser.
+ *
+ * Used by Phase 7 waves 2-5: every non-auth server action calls this to
+ * get a bearer before hitting the .NET API. Returns null if the refresh
+ * cookie is missing / invalid — the caller should then surface a 401 to
+ * the browser so the AuthProvider can bounce to /login.
+ *
+ * KNOWN LIMITATION: two Server Actions that mint concurrently present the
+ * same refresh cookie; the backend's reuse-detection (Phase 3) will revoke
+ * the family and log everyone out. If this bites in practice, the backend
+ * needs a non-rotating mint variant (tracked as a Wave 2 decision).
+ */
+export async function mintBackendAccessToken(): Promise<string | null> {
+  const cookieHeader = await forwardedRefreshCookieHeader();
+  if (!cookieHeader) return null;
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBase()}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookieHeader,
+      },
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      const cookieStore = await cookies();
+      cookieStore.delete(REFRESH_COOKIE_NAME);
+    }
+    return null;
+  }
+
+  await proxyRefreshCookie(response);
+  const data = (await response.json()) as { accessToken: string };
+  return data.accessToken;
+}
+
+export async function logoutAction(): Promise<{ ok: true }> {
+  const cookieHeader = await forwardedRefreshCookieHeader();
+
+  try {
+    await fetch(`${apiBase()}/api/auth/logout`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+      },
+    });
+  } catch {
+    // Server-side revocation is best-effort; local cookie cleanup below
+    // is what actually ends the session from the browser's perspective.
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.delete(REFRESH_COOKIE_NAME);
+  return { ok: true };
+}

--- a/apps/web/lib/validation/login.ts
+++ b/apps/web/lib/validation/login.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { JAPAN_PHONE_LOCAL_DIGITS } from "@/lib/phone";
+
+// Login input shape. The form submits the same fields for either mode; the
+// discriminator 'mode' decides which of password / pin is required.
+
+const phoneSchema = z
+  .string()
+  .regex(new RegExp(`^\\d{${JAPAN_PHONE_LOCAL_DIGITS}}$`), {
+    message: "Phone number must be exactly 11 digits.",
+  });
+
+export const staffLoginSchema = z.object({
+  mode: z.literal("staff"),
+  phone: phoneSchema,
+  // Login itself does NOT validate password strength (see Phase 2 —
+  // legacy-password users must be able to sign in so we can force them
+  // through the change-password flow).
+  password: z.string().min(1, "Password is required."),
+});
+
+export const parentLoginSchema = z.object({
+  mode: z.literal("parent"),
+  phone: phoneSchema,
+  pin: z.string().regex(/^\d{4,6}$/, "PIN must be 4 to 6 digits."),
+});
+
+export const loginSchema = z.discriminatedUnion("mode", [
+  staffLoginSchema,
+  parentLoginSchema,
+]);
+
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/apps/web/providers/auth-provider.tsx
+++ b/apps/web/providers/auth-provider.tsx
@@ -14,6 +14,7 @@ import type { AuthUser } from "@/lib/auth/jwt";
 import { getUserFromToken, secondsUntilExpiry } from "@/lib/auth/jwt";
 import { tokenStore } from "@/lib/auth/token-store";
 import { refreshAccessToken } from "@/lib/api-client";
+import { logoutAction } from "@/lib/actions/auth-actions";
 
 interface AuthContextType {
   token: string | null;
@@ -73,16 +74,11 @@ export function AuthProvider({
   }, []);
 
   const logout = useCallback(async (): Promise<void> => {
-    // Best-effort server logout; local state still cleared on failure.
-    const bearer = tokenStore.get();
+    // Server action: revokes refresh tokens on the backend and deletes the
+    // HttpOnly refresh cookie server-side. Best-effort — local state is
+    // still cleared below if the action throws.
     try {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/logout`, {
-        method: "POST",
-        credentials: "include",
-        headers: bearer
-          ? { Authorization: `Bearer ${bearer}`, "Content-Type": "application/json" }
-          : { "Content-Type": "application/json" },
-      });
+      await logoutAction();
     } catch {
       // Ignore — we still clean up locally.
     }


### PR DESCRIPTION
Ships the first wave of the Server Actions migration (the decision gate from the Phase 7 audit landed on "migrate"). This wave moves just the authentication surface — login and logout — and establishes the shape every subsequent wave will repeat for homework, attendance, notices, and user CRUD.

Web (apps/web):
- New lib/validation/login.ts — Zod discriminated union over staff vs parent login. Mirrors the existing client-side inline validation so the Server Action parses the exact same schema the form rendered.
- New lib/actions/auth-actions.ts (all "use server"):
  - loginAction(prev, formData) — validates, calls /api/auth/login or /login-parent, proxies the .NET Set-Cookie back to the browser via next/headers.cookies() with HttpOnly + Secure (prod) + Strict + Path=/ re-applied as app invariants (not trusted from upstream). Returns a { ok, data | fieldErrors | formError } discriminated result; never throws on expected validation failures.
  - logoutAction() — forwards the browser's HttpOnly refresh cookie to /api/auth/logout with an explicit Cookie: header, then deletes the cookie server-side. Best-effort on the backend round-trip; the cookie clear is what actually ends the session from the browser's perspective.
  - mintBackendAccessToken() — helper for waves 2-5. Uses the HttpOnly refresh cookie to mint a per-action bearer token via /api/auth/refresh, proxies the rotated refresh cookie, returns null if refresh fails. Known concurrent-mint limitation (can burn the refresh-token family under parallel actions) is documented in docs/server-actions.md; addressing it is a Wave 2 decision.
- login-form.tsx rewritten to useActionState(loginAction, null). Local state is kept only for controls that don't belong in FormData (mode toggle, phone live-format, show/hide password). Pending state drives the submit button from useFormStatus semantics. On success the form still calls login(token, expiresIn) on useAuth to populate the in-memory tokenStore — Phase 3's access-token handling is unchanged.
- auth-provider.logout() now calls logoutAction() instead of a raw client-side fetch; the browser no longer touches the .NET /logout endpoint directly.

Docs:
- apps/web/docs/server-actions.md documents the per-action shape, token-flow pattern, migration order (waves 2-5), and known limitations so each subsequent PR looks identical to this one.

No backend changes. No database changes. Extends-only at the HTTP layer: the .NET endpoints are unchanged; the Next.js app just moved its own mutation path server-side.

Rollback: revert this commit. The previous browser-fetch path still works as long as tokenStore and api-client remain intact (they do).