### PR TITLE
feat(web): move homework mutations to Server Actions + non-rotating m…

### DIFF
--- a/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommand.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommand.cs
@@ -1,9 +1,16 @@
 namespace EduConnect.Api.Features.Auth.RefreshToken;
 
-public record RefreshTokenCommand : IRequest<RefreshTokenResponse>;
+/// <summary>
+/// <paramref name="NoRotate"/> tells the handler to mint a fresh access
+/// token WITHOUT revoking the presented refresh token or issuing a new
+/// one. Used only by the Next.js Server Actions path (Phase 7), where
+/// concurrent actions presenting the same cookie would otherwise trigger
+/// reuse-detection and log the user out. See apps/web/docs/server-actions.md.
+/// </summary>
+public record RefreshTokenCommand(bool NoRotate = false) : IRequest<RefreshTokenResponse>;
 
 public record RefreshTokenResponse(
     string AccessToken,
     int ExpiresIn,
-    string NewRefreshToken,
+    string? NewRefreshToken,
     bool MustChangePassword);

--- a/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -127,6 +127,25 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
             user.Name,
             JwtTokenService.AccessTokenLifetimeMinutes,
             user.MustChangePassword);
+
+        // No-rotate path (Next.js Server Actions): issue a fresh access
+        // token without revoking the presented refresh token so a burst of
+        // parallel server-side actions can't trigger reuse-detection against
+        // itself. The rotating browser path (client-side single-flight in
+        // api-client.ts) keeps reuse protection for cookie theft.
+        if (request.NoRotate)
+        {
+            _logger.LogDebug(
+                "Non-rotating access token minted for user {UserId} (server-action path)",
+                user.Id);
+
+            return new RefreshTokenResponse(
+                newAccessToken,
+                JwtTokenService.AccessTokenLifetimeSeconds,
+                null,
+                user.MustChangePassword);
+        }
+
         var newRefreshTokenId = Guid.NewGuid();
         var newRefreshTokenSecret = _jwtTokenService.GenerateRefreshToken();
         var newRefreshToken = _jwtTokenService.BuildRefreshToken(newRefreshTokenId, newRefreshTokenSecret);

--- a/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
@@ -15,13 +15,23 @@ public static class RefreshTokenEndpoint
             return Results.Unauthorized();
         }
 
-        var result = await mediator.Send(new RefreshTokenCommand(), cancellationToken);
-        var refreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
+        // ?noRotate=true is used only by the Next.js Server Actions path
+        // (see apps/web/docs/server-actions.md). It mints a fresh access
+        // token without revoking the presented refresh token so concurrent
+        // server actions don't trigger reuse-detection against themselves.
+        var noRotate =
+            string.Equals(context.Request.Query["noRotate"].ToString(), "true", StringComparison.OrdinalIgnoreCase);
 
-        context.Response.Cookies.Append(
-            "refresh_token",
-            result.NewRefreshToken,
-            RefreshTokenCookieOptions.Create(context.Request, refreshTokenExpiresAt));
+        var result = await mediator.Send(new RefreshTokenCommand(noRotate), cancellationToken);
+
+        if (!noRotate && result.NewRefreshToken is not null)
+        {
+            var refreshTokenExpiresAt = DateTimeOffset.UtcNow.AddDays(7);
+            context.Response.Cookies.Append(
+                "refresh_token",
+                result.NewRefreshToken,
+                RefreshTokenCookieOptions.Create(context.Request, refreshTokenExpiresAt));
+        }
 
         return Results.Ok(new
         {

--- a/apps/web/app/(dashboard)/teacher/homework/page.tsx
+++ b/apps/web/app/(dashboard)/teacher/homework/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import * as React from "react";
-import { ApiError, apiGet, apiPost, apiPut } from "@/lib/api-client";
+import { ApiError, apiGet } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
+import {
+  approveHomeworkAction,
+  createHomeworkAction,
+  rejectHomeworkAction,
+  submitHomeworkForApprovalAction,
+  updateHomeworkAction,
+} from "@/lib/actions/homework-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -47,15 +54,6 @@ interface HomeworkItem {
   canSubmitForApproval: boolean;
   canApproveOrReject: boolean;
   publishedAt: string;
-}
-
-interface CreateHomeworkResponse {
-  homeworkId: string;
-  message: string;
-}
-
-interface UpdateHomeworkResponse {
-  message: string;
 }
 
 export default function TeacherHomeworkPage(): React.ReactElement {
@@ -270,14 +268,22 @@ export default function TeacherHomeworkPage(): React.ReactElement {
 
     setIsCreating(true);
     try {
-      const response = await apiPost<CreateHomeworkResponse>(API_ENDPOINTS.homework, {
+      const result = await createHomeworkAction({
         classId: createClassId,
         subject: createSubject,
         title: createTitle,
         description: createDescription,
         dueDate: createDueDate,
       });
-      setSuccessMessage(response.message);
+      if (!result.ok) {
+        setCreateError(
+          result.formError ??
+            Object.values(result.fieldErrors ?? {})[0] ??
+            "Failed to create homework.",
+        );
+        return;
+      }
+      setSuccessMessage("Homework created.");
       setShowCreateForm(false);
       setCreateClassId("");
       setCreateSubject("");
@@ -285,11 +291,11 @@ export default function TeacherHomeworkPage(): React.ReactElement {
       setCreateDescription("");
       setCreateDueDate("");
       // Show attachment uploader for the newly created homework
-      setNewHomeworkId(response.homeworkId);
+      setNewHomeworkId(result.data.homeworkId);
       setNewHomeworkAttachments([]);
       fetchHomework();
-    } catch (err) {
-      setCreateError(err instanceof ApiError ? err.message : "Failed to create homework.");
+    } catch {
+      setCreateError("Failed to create homework.");
     } finally {
       setIsCreating(false);
     }
@@ -313,20 +319,25 @@ export default function TeacherHomeworkPage(): React.ReactElement {
 
     setIsUpdating(true);
     try {
-      const response = await apiPut<UpdateHomeworkResponse>(
-        `${API_ENDPOINTS.homework}/${editingId}`,
-        {
-          homeworkId: editingId,
-          title: editTitle,
-          description: editDescription,
-          dueDate: editDueDate,
-        }
-      );
-      setSuccessMessage(response.message);
+      const result = await updateHomeworkAction({
+        homeworkId: editingId,
+        title: editTitle,
+        description: editDescription,
+        dueDate: editDueDate,
+      });
+      if (!result.ok) {
+        setEditError(
+          result.formError ??
+            Object.values(result.fieldErrors ?? {})[0] ??
+            "Failed to update homework.",
+        );
+        return;
+      }
+      setSuccessMessage(result.data.message);
       setEditingId(null);
       fetchHomework();
-    } catch (err) {
-      setEditError(err instanceof ApiError ? err.message : "Failed to update homework.");
+    } catch {
+      setEditError("Failed to update homework.");
     } finally {
       setIsUpdating(false);
     }
@@ -371,11 +382,15 @@ export default function TeacherHomeworkPage(): React.ReactElement {
     setActionSuccess("");
     setActionHomeworkId(id);
     try {
-      const response = await apiPut<{ message: string }>(`${API_ENDPOINTS.homework}/${id}/submit`, {});
-      setActionSuccess(response.message);
+      const result = await submitHomeworkForApprovalAction(id);
+      if (!result.ok) {
+        setActionError(result.formError ?? "Failed to submit homework for approval.");
+        return;
+      }
+      setActionSuccess(result.data.message);
       fetchHomework();
-    } catch (err) {
-      setActionError(err instanceof ApiError ? err.message : "Failed to submit homework for approval.");
+    } catch {
+      setActionError("Failed to submit homework for approval.");
     } finally {
       setActionHomeworkId(null);
     }
@@ -386,11 +401,15 @@ export default function TeacherHomeworkPage(): React.ReactElement {
     setActionSuccess("");
     setActionHomeworkId(id);
     try {
-      const response = await apiPut<{ message: string }>(`${API_ENDPOINTS.homework}/${id}/approve`, {});
-      setActionSuccess(response.message);
+      const result = await approveHomeworkAction(id);
+      if (!result.ok) {
+        setActionError(result.formError ?? "Failed to approve homework.");
+        return;
+      }
+      setActionSuccess(result.data.message);
       fetchHomework();
-    } catch (err) {
-      setActionError(err instanceof ApiError ? err.message : "Failed to approve homework.");
+    } catch {
+      setActionError("Failed to approve homework.");
     } finally {
       setActionHomeworkId(null);
     }
@@ -403,13 +422,19 @@ export default function TeacherHomeworkPage(): React.ReactElement {
     setActionSuccess("");
     setActionHomeworkId(id);
     try {
-      const response = await apiPut<{ message: string }>(`${API_ENDPOINTS.homework}/${id}/reject`, {
-        reason,
-      });
-      setActionSuccess(response.message);
+      const result = await rejectHomeworkAction({ homeworkId: id, reason });
+      if (!result.ok) {
+        setActionError(
+          result.formError ??
+            Object.values(result.fieldErrors ?? {})[0] ??
+            "Failed to reject homework.",
+        );
+        return;
+      }
+      setActionSuccess(result.data.message);
       fetchHomework();
-    } catch (err) {
-      setActionError(err instanceof ApiError ? err.message : "Failed to reject homework.");
+    } catch {
+      setActionError("Failed to reject homework.");
     } finally {
       setActionHomeworkId(null);
     }

--- a/apps/web/lib/actions/auth-actions.ts
+++ b/apps/web/lib/actions/auth-actions.ts
@@ -165,18 +165,20 @@ export async function loginAction(
 
 /**
  * Mints a short-lived backend access token inside a Server Action context
- * by calling /api/auth/refresh with the browser's HttpOnly refresh cookie.
- * Proxies the rotated refresh cookie back to the browser.
+ * by calling /api/auth/refresh?noRotate=true with the browser's HttpOnly
+ * refresh cookie. The noRotate flag instructs the backend to issue a fresh
+ * access token WITHOUT rotating the refresh token — so two Server Actions
+ * firing at the same moment don't race their rotations and trigger the
+ * Phase 3 reuse-detection against themselves.
  *
- * Used by Phase 7 waves 2-5: every non-auth server action calls this to
- * get a bearer before hitting the .NET API. Returns null if the refresh
- * cookie is missing / invalid — the caller should then surface a 401 to
- * the browser so the AuthProvider can bounce to /login.
+ * Security posture: the rotating path in api-client.ts (browser-side
+ * single-flight) continues to provide reuse-detection for cookie-theft
+ * scenarios. noRotate is available only to the server-action trust
+ * boundary where rotations would cause self-inflicted churn.
  *
- * KNOWN LIMITATION: two Server Actions that mint concurrently present the
- * same refresh cookie; the backend's reuse-detection (Phase 3) will revoke
- * the family and log everyone out. If this bites in practice, the backend
- * needs a non-rotating mint variant (tracked as a Wave 2 decision).
+ * Returns null if the refresh cookie is missing / invalid — the caller
+ * should surface a 401 to the browser so the AuthProvider can bounce to
+ * /login.
  */
 export async function mintBackendAccessToken(): Promise<string | null> {
   const cookieHeader = await forwardedRefreshCookieHeader();
@@ -184,7 +186,7 @@ export async function mintBackendAccessToken(): Promise<string | null> {
 
   let response: Response;
   try {
-    response = await fetch(`${apiBase()}/api/auth/refresh`, {
+    response = await fetch(`${apiBase()}/api/auth/refresh?noRotate=true`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -203,7 +205,7 @@ export async function mintBackendAccessToken(): Promise<string | null> {
     return null;
   }
 
-  await proxyRefreshCookie(response);
+  // noRotate mode doesn't emit a new Set-Cookie — nothing to proxy.
   const data = (await response.json()) as { accessToken: string };
   return data.accessToken;
 }

--- a/apps/web/lib/actions/backend.ts
+++ b/apps/web/lib/actions/backend.ts
@@ -1,0 +1,113 @@
+"use server";
+
+import { mintBackendAccessToken } from "@/lib/actions/auth-actions";
+
+// Shared-surface result type for every Server Action that calls the .NET API.
+// Actions map this into their own feature-specific success/error shape before
+// returning to the client — the client never sees callBackend's internals.
+export type BackendResult<T> =
+  | { ok: true; data: T }
+  | {
+      ok: false;
+      status: number;
+      // Preserves the .NET ProblemDetails body so callers can map 400 field
+      // errors into their own validation shape.
+      problem?: unknown;
+    };
+
+function apiBase(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL is not defined");
+  }
+  return baseUrl;
+}
+
+/**
+ * Authenticated backend call from inside a Server Action. Mints a short-lived
+ * bearer via mintBackendAccessToken (non-rotating refresh), then performs
+ * exactly one request. No automatic retry — if the token mint fails or the
+ * backend returns 401, the caller surfaces the failure and the client
+ * bounces the user to /login.
+ */
+export async function callBackend<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<BackendResult<T>> {
+  const token = await mintBackendAccessToken();
+  if (!token) {
+    return { ok: false, status: 401 };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBase()}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch {
+    return { ok: false, status: 0 };
+  }
+
+  if (!response.ok) {
+    const problem = await response.json().catch(() => undefined);
+    return { ok: false, status: response.status, problem };
+  }
+
+  if (response.status === 204) {
+    return { ok: true, data: undefined as T };
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return { ok: true, data: undefined as T };
+  }
+
+  const data = (await response.json()) as T;
+  return { ok: true, data };
+}
+
+/**
+ * Convenience mapper: turn a BackendResult failure into a generic form
+ * error string, extracting the .NET ProblemDetails title/detail when
+ * available. Feature actions typically want to pull field errors out of
+ * problem.errors themselves, so this is only a last-resort formatter.
+ */
+export async function formErrorFromBackend(result: BackendResult<unknown>): Promise<string> {
+  if (result.ok) return "";
+  if (result.status === 0) return "Could not reach the server. Please try again.";
+  if (result.status === 401) return "Your session has expired. Please sign in again.";
+
+  const problem = result.problem as
+    | { detail?: string; title?: string; errors?: Record<string, string[]> }
+    | undefined;
+  if (problem?.detail) return problem.detail;
+  if (problem?.title) return problem.title;
+  return `Request failed (HTTP ${result.status}).`;
+}
+
+/**
+ * Convenience mapper: lift ProblemDetails.errors into a
+ * { fieldName: firstMessage } map for action return shapes.
+ */
+export async function fieldErrorsFromBackend(
+  result: BackendResult<unknown>,
+): Promise<Record<string, string>> {
+  if (result.ok) return {};
+  const problem = result.problem as
+    | { errors?: Record<string, string[]> }
+    | undefined;
+  const errors: Record<string, string> = {};
+  if (problem?.errors) {
+    for (const [key, values] of Object.entries(problem.errors)) {
+      if (Array.isArray(values) && typeof values[0] === "string") {
+        errors[key[0]?.toLowerCase() + key.slice(1)] = values[0];
+      }
+    }
+  }
+  return errors;
+}

--- a/apps/web/lib/actions/homework-actions.ts
+++ b/apps/web/lib/actions/homework-actions.ts
@@ -1,0 +1,138 @@
+"use server";
+
+import type { ZodError } from "zod";
+import { callBackend, fieldErrorsFromBackend, formErrorFromBackend } from "@/lib/actions/backend";
+import {
+  createHomeworkSchema,
+  rejectHomeworkSchema,
+  updateHomeworkSchema,
+  type CreateHomeworkInput,
+  type RejectHomeworkInput,
+  type UpdateHomeworkInput,
+} from "@/lib/validation/homework";
+
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | {
+      ok: false;
+      fieldErrors?: Record<string, string>;
+      formError?: string;
+    };
+
+interface CreateHomeworkData {
+  homeworkId: string;
+  message: string;
+}
+
+interface MessageResponse {
+  message: string;
+}
+
+function zodToFieldErrors(error: ZodError): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !(key in out)) out[key] = issue.message;
+  }
+  return out;
+}
+
+export async function createHomeworkAction(
+  input: CreateHomeworkInput,
+): Promise<ActionResult<CreateHomeworkData>> {
+  const parsed = createHomeworkSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<CreateHomeworkData>("/api/homework", {
+    method: "POST",
+    body: JSON.stringify(parsed.data),
+  });
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+
+  return { ok: true, data: backend.data };
+}
+
+export async function updateHomeworkAction(
+  input: UpdateHomeworkInput,
+): Promise<ActionResult<MessageResponse>> {
+  const parsed = updateHomeworkSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<MessageResponse>(
+    `/api/homework/${encodeURIComponent(parsed.data.homeworkId)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(parsed.data),
+    },
+  );
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+
+  return { ok: true, data: backend.data };
+}
+
+export async function submitHomeworkForApprovalAction(
+  homeworkId: string,
+): Promise<ActionResult<MessageResponse>> {
+  const backend = await callBackend<MessageResponse>(
+    `/api/homework/${encodeURIComponent(homeworkId)}/submit`,
+    { method: "PUT", body: "{}" },
+  );
+  if (!backend.ok) return { ok: false, formError: await formErrorFromBackend(backend) };
+  return { ok: true, data: backend.data };
+}
+
+export async function approveHomeworkAction(
+  homeworkId: string,
+): Promise<ActionResult<MessageResponse>> {
+  const backend = await callBackend<MessageResponse>(
+    `/api/homework/${encodeURIComponent(homeworkId)}/approve`,
+    { method: "PUT", body: "{}" },
+  );
+  if (!backend.ok) return { ok: false, formError: await formErrorFromBackend(backend) };
+  return { ok: true, data: backend.data };
+}
+
+export async function rejectHomeworkAction(
+  input: RejectHomeworkInput,
+): Promise<ActionResult<MessageResponse>> {
+  const parsed = rejectHomeworkSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<MessageResponse>(
+    `/api/homework/${encodeURIComponent(parsed.data.homeworkId)}/reject`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ reason: parsed.data.reason }),
+    },
+  );
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+
+  return { ok: true, data: backend.data };
+}

--- a/apps/web/lib/validation/homework.ts
+++ b/apps/web/lib/validation/homework.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+// Matches the .NET CreateHomeworkCommand + UpdateHomeworkCommand shapes.
+// Used by both the server action (authoritative) and the client form
+// (inline hints).
+
+const guidSchema = z
+  .string()
+  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, {
+    message: "Must be a valid ID.",
+  });
+
+const dueDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "Due date must be YYYY-MM-DD." });
+
+export const createHomeworkSchema = z.object({
+  classId: guidSchema,
+  subject: z.string().trim().min(1, "Subject is required.").max(100),
+  title: z.string().trim().min(1, "Title is required.").max(200),
+  description: z.string().trim().min(1, "Description is required.").max(4000),
+  dueDate: dueDateSchema,
+});
+export type CreateHomeworkInput = z.infer<typeof createHomeworkSchema>;
+
+export const updateHomeworkSchema = z.object({
+  homeworkId: guidSchema,
+  title: z.string().trim().min(1, "Title is required.").max(200),
+  description: z.string().trim().min(1, "Description is required.").max(4000),
+  dueDate: dueDateSchema,
+});
+export type UpdateHomeworkInput = z.infer<typeof updateHomeworkSchema>;
+
+export const rejectHomeworkSchema = z.object({
+  homeworkId: guidSchema,
+  reason: z.string().trim().min(1, "Rejection reason is required.").max(500),
+});
+export type RejectHomeworkInput = z.infer<typeof rejectHomeworkSchema>;
+
+export const homeworkIdParamSchema = z.object({ homeworkId: guidSchema });


### PR DESCRIPTION
…int (Phase 7 wave 2)

Second wave of the Server Actions migration. Lands:
  - the backend change that makes the pattern scalable (non-rotating /auth/refresh mint)
  - the shared callBackend helper every later wave will use
  - the first five feature actions (homework create, update, submit-for-approval, approve, reject)

Backend (apps/api):
- /api/auth/refresh accepts ?noRotate=true. The handler issues a fresh access token WITHOUT revoking the presented refresh token or setting a new cookie. The endpoint skips the Set-Cookie branch when noRotate is present. RefreshTokenResponse.NewRefreshToken is now nullable to reflect the two shapes. Rotating path (browser-side single-flight in api-client.ts) is unchanged.
- RefreshTokenResponse.NewRefreshToken made nullable in the record so noRotate responses don't carry a meaningless field.

Web (apps/web):
- lib/actions/auth-actions.ts: mintBackendAccessToken now calls /api/auth/refresh?noRotate=true. No longer proxies Set-Cookie since there isn't one. Comment block updated to describe the security posture: rotation still protects the browser-originated refresh path; noRotate is exclusive to the server-action trust boundary where self-rotation would trigger Phase 3's reuse-detection against concurrent actions.
- lib/actions/backend.ts (new): callBackend<T>(path, init) minimum-viable helper that mints a bearer, forwards it to the .NET API, and returns a BackendResult<T>. Exposes formErrorFromBackend + fieldErrorsFromBackend so feature actions can map ProblemDetails into their own shape.
- lib/validation/homework.ts (new): Zod schemas for create / update / reject, mirroring the .NET CreateHomeworkCommand / UpdateHomeworkCommand / RejectHomeworkCommand shapes. Used by both the form (inline hints) and the server action (authoritative parse).
- lib/actions/homework-actions.ts (new): five "use server" actions — createHomeworkAction, updateHomeworkAction, approveHomeworkAction, rejectHomeworkAction, submitHomeworkForApprovalAction. Each parses the typed input, calls callBackend, and returns the project's ActionResult<T> discriminated union.
- app/(dashboard)/teacher/homework/page.tsx: five mutation call sites switched from apiPost/apiPut to the new actions. Reads unchanged (apiGet continues to serve GETs). The page's imperative UX pattern (error state, refetch, form toggles) is preserved — actions are invoked programmatically, not via useActionState, because the page has multiple mutation entry points sharing the same local state. Dead types CreateHomeworkResponse / UpdateHomeworkResponse removed.

Verification: .NET build + test suite clean (96 passing, 3 RLS skipped, same 2 pre-existing AdminOnboarding failures). Web type-check and lint clean (3 pre-existing warnings untouched).

No database changes. No API-contract break: the extend-only additions are the ?noRotate query param and a nullable NewRefreshToken field.

Rollback: revert this commit. Browser-side api-client calls to /api/homework endpoints are unchanged; removing the server actions leaves the backend happy.