### PR TITLE
feat(web): move attendance + leave mutations to Server Actions (Phase…

### DIFF
--- a/apps/web/app/(dashboard)/parent/attendance/page.tsx
+++ b/apps/web/app/(dashboard)/parent/attendance/page.tsx
@@ -2,16 +2,18 @@
 
 import * as React from "react";
 import { useAuth } from "@/hooks/use-auth";
-import { apiDelete, apiGet, apiPost, apiPut, ApiError } from "@/lib/api-client";
+import { apiGet, ApiError } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
+import {
+  applyLeaveAction,
+  cancelLeaveAction,
+  updateLeaveAction,
+} from "@/lib/actions/attendance-actions";
 import { useParentChildren } from "@/hooks/use-parent-children";
 import { ALL_CHILDREN_VALUE } from "@/lib/parent-children";
 import type {
   AttendanceRecord,
   LeaveApplication,
-  ApplyLeaveRequest,
-  ApplyLeaveResponse,
-  UpdateLeaveRequest,
   GetLeaveApplicationsResponse,
 } from "@/lib/types/attendance";
 import type { ParentChildItem } from "@/lib/types/student";
@@ -169,23 +171,40 @@ function LeaveApplicationForm({
     setIsSubmitting(true);
     try {
       if (isEditing && initialLeave?.id) {
-        const payload: UpdateLeaveRequest = { startDate, endDate, reason };
-        await apiPut(`${API_ENDPOINTS.leaveApplications}/${initialLeave.id}`, payload);
+        const result = await updateLeaveAction({
+          leaveApplicationId: initialLeave.id,
+          startDate,
+          endDate,
+          reason,
+        });
+        if (!result.ok) {
+          setError(
+            result.formError ??
+              Object.values(result.fieldErrors ?? {})[0] ??
+              "Failed to submit leave application.",
+          );
+          return;
+        }
       } else {
-        const payload: ApplyLeaveRequest = {
+        const result = await applyLeaveAction({
           studentIds: selectedStudentIds,
           startDate,
           endDate,
           reason,
-        };
-        await apiPost<ApplyLeaveResponse>(API_ENDPOINTS.leaveApplications, payload);
+        });
+        if (!result.ok) {
+          setError(
+            result.formError ??
+              Object.values(result.fieldErrors ?? {})[0] ??
+              "Failed to submit leave application.",
+          );
+          return;
+        }
       }
       onSuccess();
       onClose();
-    } catch (err) {
-      const message =
-        err instanceof ApiError ? err.message : "Failed to submit leave application.";
-      setError(message);
+    } catch {
+      setError("Failed to submit leave application.");
     } finally {
       setIsSubmitting(false);
     }
@@ -494,11 +513,15 @@ export default function ParentAttendancePage(): React.ReactElement {
     if (!ok) return;
 
     try {
-      await apiDelete(`${API_ENDPOINTS.leaveApplications}/${leaveId}`);
+      const result = await cancelLeaveAction(leaveId);
+      if (!result.ok) {
+        setLeavesError(result.formError ?? "Failed to cancel leave application.");
+        return;
+      }
       fetchLeaves();
-    } catch (err) {
+    } catch {
       setLeavesError(
-        err instanceof ApiError ? err.message : "Failed to cancel leave application."
+        "Failed to cancel leave application."
       );
     }
   };

--- a/apps/web/app/(dashboard)/teacher/attendance/page.tsx
+++ b/apps/web/app/(dashboard)/teacher/attendance/page.tsx
@@ -2,8 +2,13 @@
 
 import * as React from "react";
 import { useAuth } from "@/hooks/use-auth";
-import { ApiError, apiGet, apiPost, apiPut } from "@/lib/api-client";
+import { ApiError, apiGet } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
+import {
+  approveLeaveAction,
+  rejectLeaveAction,
+  submitAttendanceTakeAction,
+} from "@/lib/actions/attendance-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -52,13 +57,6 @@ interface TakeContextResponse {
   exceptions: TakeException[];
   approvedLeaves: TakeLeave[];
   pendingLeaves: TakeLeave[];
-}
-
-interface SubmitAttendanceResponse {
-  createdCount: number;
-  updatedCount: number;
-  clearedCount: number;
-  message: string;
 }
 
 // How many days back a teacher is allowed to mark attendance for. Kept in
@@ -254,11 +252,22 @@ export default function TeacherAttendancePage(): React.ReactElement {
         reason: (reasonByStudentId[s.id] ?? "").trim() || null,
       }));
 
-      const res = await apiPost<SubmitAttendanceResponse>(`${API_ENDPOINTS.attendance}/take`, {
+      const actionResult = await submitAttendanceTakeAction({
         classId: context.classId,
         date: context.date,
         items,
       });
+
+      if (!actionResult.ok) {
+        setActionError(
+          actionResult.formError ??
+            Object.values(actionResult.fieldErrors ?? {})[0] ??
+            "Failed to save attendance.",
+        );
+        return;
+      }
+
+      const res = actionResult.data;
 
       // Lock the UI IMMEDIATELY on a successful POST. Previously we waited
       // for the follow-up refetch to succeed before calling setHasSaved(true)
@@ -322,14 +331,15 @@ export default function TeacherAttendancePage(): React.ReactElement {
     setActionError("");
     setActionSuccess("");
     try {
-      const res = await apiPut<{ message: string }>(
-        `${API_ENDPOINTS.leaveApplications}/${leaveId}/approve`,
-        {}
-      );
-      setActionSuccess(res.message);
+      const result = await approveLeaveAction(leaveId);
+      if (!result.ok) {
+        setActionError(result.formError ?? "Failed to approve leave.");
+        return;
+      }
+      setActionSuccess(result.data.message);
       await fetchContext();
-    } catch (err) {
-      setActionError(err instanceof ApiError ? err.message : "Failed to approve leave.");
+    } catch {
+      setActionError("Failed to approve leave.");
     } finally {
       setLeaveActionId(null);
     }
@@ -343,14 +353,19 @@ export default function TeacherAttendancePage(): React.ReactElement {
     setActionError("");
     setActionSuccess("");
     try {
-      const res = await apiPut<{ message: string }>(
-        `${API_ENDPOINTS.leaveApplications}/${leaveId}/reject`,
-        { reviewNote: note }
-      );
-      setActionSuccess(res.message);
+      const result = await rejectLeaveAction({ leaveApplicationId: leaveId, reviewNote: note });
+      if (!result.ok) {
+        setActionError(
+          result.formError ??
+            Object.values(result.fieldErrors ?? {})[0] ??
+            "Failed to reject leave.",
+        );
+        return;
+      }
+      setActionSuccess(result.data.message);
       await fetchContext();
-    } catch (err) {
-      setActionError(err instanceof ApiError ? err.message : "Failed to reject leave.");
+    } catch {
+      setActionError("Failed to reject leave.");
     } finally {
       setLeaveActionId(null);
     }

--- a/apps/web/lib/actions/attendance-actions.ts
+++ b/apps/web/lib/actions/attendance-actions.ts
@@ -1,0 +1,171 @@
+"use server";
+
+import type { ZodError } from "zod";
+import { callBackend, fieldErrorsFromBackend, formErrorFromBackend } from "@/lib/actions/backend";
+import {
+  applyLeaveSchema,
+  rejectLeaveSchema,
+  submitAttendanceTakeSchema,
+  updateLeaveSchema,
+  type ApplyLeaveInput,
+  type RejectLeaveInput,
+  type SubmitAttendanceTakeInput,
+  type UpdateLeaveInput,
+} from "@/lib/validation/attendance";
+
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; fieldErrors?: Record<string, string>; formError?: string };
+
+interface MessageResponse {
+  message: string;
+}
+
+interface SubmitAttendanceResponse {
+  createdCount: number;
+  updatedCount: number;
+  clearedCount: number;
+  message: string;
+}
+
+interface ApplyLeaveResponse {
+  leaveApplicationId: string;
+  leaveApplicationIds: string[];
+  createdCount: number;
+  status: string;
+  message: string;
+}
+
+function zodToFieldErrors(error: ZodError): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const key = issue.path[0];
+    if (typeof key === "string" && !(key in out)) out[key] = issue.message;
+  }
+  return out;
+}
+
+export async function submitAttendanceTakeAction(
+  input: SubmitAttendanceTakeInput,
+): Promise<ActionResult<SubmitAttendanceResponse>> {
+  const parsed = submitAttendanceTakeSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<SubmitAttendanceResponse>("/api/attendance/take", {
+    method: "POST",
+    body: JSON.stringify(parsed.data),
+  });
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+  return { ok: true, data: backend.data };
+}
+
+export async function applyLeaveAction(
+  input: ApplyLeaveInput,
+): Promise<ActionResult<ApplyLeaveResponse>> {
+  const parsed = applyLeaveSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<ApplyLeaveResponse>("/api/leave-applications", {
+    method: "POST",
+    body: JSON.stringify(parsed.data),
+  });
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+  return { ok: true, data: backend.data };
+}
+
+export async function updateLeaveAction(
+  input: UpdateLeaveInput,
+): Promise<ActionResult<MessageResponse>> {
+  const parsed = updateLeaveSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<MessageResponse>(
+    `/api/leave-applications/${encodeURIComponent(parsed.data.leaveApplicationId)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        startDate: parsed.data.startDate,
+        endDate: parsed.data.endDate,
+        reason: parsed.data.reason,
+      }),
+    },
+  );
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      fieldErrors: await fieldErrorsFromBackend(backend),
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+  return { ok: true, data: backend.data };
+}
+
+export async function approveLeaveAction(
+  leaveApplicationId: string,
+): Promise<ActionResult<MessageResponse>> {
+  const backend = await callBackend<MessageResponse>(
+    `/api/leave-applications/${encodeURIComponent(leaveApplicationId)}/approve`,
+    { method: "PUT", body: "{}" },
+  );
+  if (!backend.ok) return { ok: false, formError: await formErrorFromBackend(backend) };
+  return { ok: true, data: backend.data };
+}
+
+export async function rejectLeaveAction(
+  input: RejectLeaveInput,
+): Promise<ActionResult<MessageResponse>> {
+  const parsed = rejectLeaveSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: zodToFieldErrors(parsed.error) };
+  }
+
+  const backend = await callBackend<MessageResponse>(
+    `/api/leave-applications/${encodeURIComponent(parsed.data.leaveApplicationId)}/reject`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ reviewNote: parsed.data.reviewNote }),
+    },
+  );
+
+  if (!backend.ok) {
+    return {
+      ok: false,
+      formError: await formErrorFromBackend(backend),
+    };
+  }
+  return { ok: true, data: backend.data };
+}
+
+export async function cancelLeaveAction(
+  leaveApplicationId: string,
+): Promise<ActionResult<{ ok: true }>> {
+  const backend = await callBackend<unknown>(
+    `/api/leave-applications/${encodeURIComponent(leaveApplicationId)}`,
+    { method: "DELETE" },
+  );
+  if (!backend.ok) {
+    return { ok: false, formError: await formErrorFromBackend(backend) };
+  }
+  return { ok: true, data: { ok: true } };
+}

--- a/apps/web/lib/validation/attendance.ts
+++ b/apps/web/lib/validation/attendance.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+const guidSchema = z
+  .string()
+  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, {
+    message: "Must be a valid ID.",
+  });
+
+const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "Date must be YYYY-MM-DD." });
+
+const attendanceStatusSchema = z.enum([
+  "Present",
+  "Absent",
+  "Late",
+  "ExcusedLeave",
+]);
+
+export const submitAttendanceTakeSchema = z.object({
+  classId: guidSchema,
+  date: isoDateSchema,
+  items: z
+    .array(
+      z.object({
+        studentId: guidSchema,
+        status: attendanceStatusSchema,
+        reason: z.string().max(500).nullable().optional(),
+      }),
+    )
+    .min(1, "At least one attendance record is required."),
+});
+export type SubmitAttendanceTakeInput = z.infer<typeof submitAttendanceTakeSchema>;
+
+export const applyLeaveSchema = z.object({
+  studentIds: z.array(guidSchema).min(1, "Select at least one child."),
+  startDate: isoDateSchema,
+  endDate: isoDateSchema,
+  reason: z.string().trim().min(1, "Reason is required.").max(500),
+});
+export type ApplyLeaveInput = z.infer<typeof applyLeaveSchema>;
+
+export const updateLeaveSchema = z.object({
+  leaveApplicationId: guidSchema,
+  startDate: isoDateSchema,
+  endDate: isoDateSchema,
+  reason: z.string().trim().min(1, "Reason is required.").max(500),
+});
+export type UpdateLeaveInput = z.infer<typeof updateLeaveSchema>;
+
+export const rejectLeaveSchema = z.object({
+  leaveApplicationId: guidSchema,
+  reviewNote: z.string().trim().min(1, "Review note is required.").max(500),
+});
+export type RejectLeaveInput = z.infer<typeof rejectLeaveSchema>;
+
+export const leaveIdSchema = z.object({ leaveApplicationId: guidSchema });


### PR DESCRIPTION
… 7 wave 3)

Third wave of the Server Actions migration. Scope:
  - teacher attendance: submit-take, approve leave, reject leave
  - parent attendance: apply leave, update leave, cancel leave

No backend changes (Wave 2's noRotate refresh already handles concurrent mints for this wave's actions). This PR is purely a web-side refactor.

Web (apps/web):
- lib/validation/attendance.ts (new): Zod schemas for submitAttendanceTake + applyLeave + updateLeave + rejectLeave, shared between form hints and the authoritative server-side parse. Attendance status enum matches the backend check-constraint set.
- lib/actions/attendance-actions.ts (new): six "use server" actions — submitAttendanceTakeAction, applyLeaveAction, updateLeaveAction, approveLeaveAction, rejectLeaveAction, cancelLeaveAction. Each calls callBackend and returns an ActionResult<T>.
- app/(dashboard)/teacher/attendance/page.tsx: three mutation call sites swapped from apiPost/apiPut to server actions. Preserves the imperative UX — submitAttendanceTake still locks the UI immediately on success, still refetches the authoritative state afterwards, still surfaces field-level errors in setActionError. Dead SubmitAttendanceResponse interface removed.
- app/(dashboard)/parent/attendance/page.tsx: three mutation call sites (leave apply / update / cancel) swapped to server actions. Dead ApplyLeaveRequest / ApplyLeaveResponse / UpdateLeaveRequest imports removed.

Verification: .NET test suite unchanged (96 passing, 3 RLS skipped, same 2 pre-existing AdminOnboarding failures). Web type-check + lint clean (3 pre-existing warnings untouched).

Follows the pattern locked in Wave 2. Reads (apiGet) continue to serve dashboards and refetches — the migration is mutation-only.

Rollback: revert. Browser-side apiPost/apiPut calls would need to be restored, but the backend endpoints are unchanged.