### PR TITLE
feat(api): Phase 2 — attach-time integrity (P0)

### DIFF
--- a/apps/api/src/EduConnect.Api/EduConnect.Api.csproj
+++ b/apps/api/src/EduConnect.Api/EduConnect.Api.csproj
@@ -38,4 +38,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="EduConnect.Api.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/AttachFileToEntity/AttachFileToEntityCommandHandler.cs
@@ -3,8 +3,10 @@ using EduConnect.Api.Features.Attachments;
 using EduConnect.Api.Common.Exceptions;
 using EduConnect.Api.Infrastructure.Database;
 using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
 using EduConnect.Api.Infrastructure.Services.Scanning;
 using MediatR;
+using Microsoft.Extensions.Options;
 
 namespace EduConnect.Api.Features.Attachments.AttachFileToEntity;
 
@@ -12,18 +14,24 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
 {
     private readonly AppDbContext _context;
     private readonly CurrentUserService _currentUserService;
+    private readonly IStorageService _storageService;
     private readonly IAttachmentScanQueue _scanQueue;
+    private readonly StorageOptions _storageOptions;
     private readonly ILogger<AttachFileToEntityCommandHandler> _logger;
 
     public AttachFileToEntityCommandHandler(
         AppDbContext context,
         CurrentUserService currentUserService,
+        IStorageService storageService,
         IAttachmentScanQueue scanQueue,
+        IOptions<StorageOptions> storageOptions,
         ILogger<AttachFileToEntityCommandHandler> logger)
     {
         _context = context;
         _currentUserService = currentUserService;
+        _storageService = storageService;
         _scanQueue = scanQueue;
+        _storageOptions = storageOptions.Value;
         _logger = logger;
     }
 
@@ -109,6 +117,65 @@ public class AttachFileToEntityCommandHandler : IRequestHandler<AttachFileToEnti
         if (existingCount >= AttachmentFeatureRules.MaxAttachmentsPerEntity)
         {
             throw new InvalidOperationException($"Maximum of {AttachmentFeatureRules.MaxAttachmentsPerEntity} attachments per entity reached.");
+        }
+
+        // Re-check AttachmentRules against the attachment row. The V2 upload
+        // validator already enforces these, but attach is the last line of
+        // defence — a V1-minted row or a row prepared for a different
+        // entity type must still be rejected here.
+        var allowedContentTypes = AttachmentFeatureRules.GetAllowedContentTypes(request.EntityType);
+        if (!allowedContentTypes.Contains(attachment.ContentType))
+        {
+            throw new InvalidOperationException(
+                $"Content type '{attachment.ContentType}' is not allowed for entity type '{request.EntityType}'.");
+        }
+
+        var allowedExtensions = AttachmentFeatureRules.GetAllowedExtensions(request.EntityType);
+        var extensionOnRow = Path.GetExtension(attachment.FileName).ToLowerInvariant();
+        if (!allowedExtensions.Contains(extensionOnRow))
+        {
+            throw new InvalidOperationException(
+                $"File extension '{extensionOnRow}' is not allowed for entity type '{request.EntityType}'.");
+        }
+
+        // Verify the client actually PUT the declared object. The size /
+        // content-type on the AttachmentEntity were client-declared when
+        // the upload URL was minted; trust is deferred until now when we
+        // compare against the storage backend's own metadata.
+        var storedMetadata = await _storageService.GetObjectMetadataAsync(
+            attachment.StorageKey,
+            cancellationToken);
+
+        if (storedMetadata is null)
+        {
+            throw new NotFoundException(
+                "File not uploaded to storage",
+                attachment.StorageKey);
+        }
+
+        if (storedMetadata.SizeBytes > _storageOptions.MaxFileSizeBytes)
+        {
+            throw new InvalidOperationException(
+                $"File exceeds max size of {_storageOptions.MaxFileSizeBytes / (1024 * 1024)}MB.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(storedMetadata.ContentType) &&
+            !string.Equals(storedMetadata.ContentType, attachment.ContentType, StringComparison.OrdinalIgnoreCase))
+        {
+            // The signed PUT URL pins Content-Type, so a mismatch here is
+            // adversarial. Fail loud rather than silently reconcile.
+            throw new InvalidOperationException(
+                $"Stored content type '{storedMetadata.ContentType}' does not match declared '{attachment.ContentType}'.");
+        }
+
+        if (storedMetadata.SizeBytes != attachment.SizeBytes)
+        {
+            _logger.LogWarning(
+                "Attachment {AttachmentId} declared size {Declared} but stored object is {Actual}; reconciling to actual.",
+                attachment.Id,
+                attachment.SizeBytes,
+                storedMetadata.SizeBytes);
+            attachment.SizeBytes = (int)storedMetadata.SizeBytes;
         }
 
         // Associate the attachment

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrl/RequestUploadUrlCommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrl/RequestUploadUrlCommandHandler.cs
@@ -59,6 +59,7 @@ public class RequestUploadUrlCommandHandler : IRequestHandler<RequestUploadUrlCo
         var uploadUrl = await _storageService.GeneratePresignedUploadUrlAsync(
             storageKey,
             request.ContentType,
+            request.SizeBytes,
             TimeSpan.FromMinutes(15),
             cancellationToken);
 

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2CommandHandler.cs
@@ -63,6 +63,7 @@ public class RequestUploadUrlV2CommandHandler : IRequestHandler<RequestUploadUrl
         var uploadUrl = await _storageService.GeneratePresignedUploadUrlAsync(
             storageKey,
             request.ContentType,
+            request.SizeBytes,
             TimeSpan.FromMinutes(_storageOptions.PresignedUploadExpiryMinutes),
             cancellationToken);
 

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/IStorageService.cs
@@ -4,10 +4,16 @@ public interface IStorageService
 {
     /// <summary>
     /// Generates a presigned URL for uploading a file directly to storage.
+    /// The signed request pins <c>Content-Length</c> to <paramref name="sizeBytes"/>
+    /// so the storage backend rejects uploads whose actual body size
+    /// differs from the caller's declared size. The client must send the
+    /// PUT with a matching <c>Content-Length</c> header (browsers do this
+    /// automatically for a Blob/File body).
     /// </summary>
     Task<string> GeneratePresignedUploadUrlAsync(
         string key,
         string contentType,
+        long sizeBytes,
         TimeSpan expiresIn,
         CancellationToken cancellationToken = default);
 
@@ -33,4 +39,18 @@ public interface IStorageService
     /// body to the scanner without a staging round-trip through disk.
     /// </summary>
     Task<Stream> OpenObjectReadStreamAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns size + content-type for the stored object, or <c>null</c>
+    /// if no object exists at the supplied key. Used by the attach path
+    /// to verify the client actually PUT a file matching the declared
+    /// size/type before linking the attachment row to an entity — so a
+    /// misbehaving client cannot cause the DB row to point at a phantom
+    /// or size/type-forged object.
+    /// </summary>
+    Task<StorageObjectMetadata?> GetObjectMetadataAsync(
+        string key,
+        CancellationToken cancellationToken = default);
 }
+
+public sealed record StorageObjectMetadata(long SizeBytes, string? ContentType);

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/S3StorageService.cs
@@ -23,6 +23,7 @@ public class S3StorageService : IStorageService
     public Task<string> GeneratePresignedUploadUrlAsync(
         string key,
         string contentType,
+        long sizeBytes,
         TimeSpan expiresIn,
         CancellationToken cancellationToken = default)
     {
@@ -35,9 +36,19 @@ public class S3StorageService : IStorageService
             ContentType = contentType
         };
 
+        // Pin the signed request to the exact byte count so S3 rejects any
+        // PUT whose Content-Length header differs. The AWS SDK v3 PUT-URL
+        // path does not expose content-length-range (that's POST-policy);
+        // including Content-Length in the signed headers delegates
+        // enforcement to the storage backend.
+        request.Headers["Content-Length"] = sizeBytes.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
         var url = _s3Client.GetPreSignedURL(request);
 
-        _logger.LogInformation("Generated presigned upload URL for key {Key}", key);
+        _logger.LogInformation(
+            "Generated presigned upload URL for key {Key} pinned to {SizeBytes} bytes",
+            key,
+            sizeBytes);
 
         return Task.FromResult(url);
     }
@@ -104,5 +115,27 @@ public class S3StorageService : IStorageService
         // Caller disposes — wrapping ensures the S3 response is released
         // when the stream is closed.
         return response.ResponseStream;
+    }
+
+    public async Task<StorageObjectMetadata?> GetObjectMetadataAsync(
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+            {
+                BucketName = _storageOptions.BucketName,
+                Key = key,
+            }, cancellationToken);
+
+            return new StorageObjectMetadata(
+                response.ContentLength,
+                response.Headers.ContentType);
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
     }
 }

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
@@ -64,7 +64,7 @@ public sealed class AttachmentScanWorker : BackgroundService
         }
     }
 
-    private async Task ScanOneAsync(Guid attachmentId, CancellationToken ct)
+    internal async Task ScanOneAsync(Guid attachmentId, CancellationToken ct)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -94,16 +94,66 @@ public sealed class AttachmentScanWorker : BackgroundService
             return;
         }
 
-        ScanResult result;
+        // Buffer so the magic-byte pre-check can read a prefix without
+        // depriving ClamAV of any bytes. 10 MB file cap (see
+        // StorageOptions.MaxFileSizeBytes) keeps the memory budget bounded.
+        await using var buffered = new MemoryStream();
         try
         {
-            await using var stream = await storage.OpenObjectReadStreamAsync(attachment.StorageKey, ct);
-            result = await scanner.ScanAsync(stream, ct);
+            await using var source = await storage.OpenObjectReadStreamAsync(attachment.StorageKey, ct);
+            await source.CopyToAsync(buffered, ct);
+            buffered.Position = 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex,
                 "Could not stream attachment {AttachmentId} from storage for scanning",
+                attachmentId);
+            attachment.Status = AttachmentStatus.ScanFailed;
+            attachment.ScannedAt = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        var prefixLength = (int)Math.Min(buffered.Length, 64);
+        var prefix = new byte[prefixLength];
+        _ = await buffered.ReadAsync(prefix.AsMemory(0, prefixLength), ct);
+        buffered.Position = 0;
+
+        if (!MimeSignatureValidator.IsConsistent(prefix, attachment.ContentType))
+        {
+            _logger.LogWarning(
+                "Attachment {AttachmentId} declared {ContentType} but magic bytes don't match; marking Infected (MIME_MISMATCH).",
+                attachmentId, attachment.ContentType);
+
+            attachment.Status = AttachmentStatus.Infected;
+            attachment.ThreatName = "MIME_MISMATCH";
+            attachment.ScannedAt = DateTimeOffset.UtcNow;
+
+            try
+            {
+                await storage.DeleteObjectAsync(attachment.StorageKey, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to delete MIME-mismatch object {Key}; DB row will stay Infected for operator cleanup",
+                    attachment.StorageKey);
+            }
+
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        ScanResult result;
+        try
+        {
+            result = await scanner.ScanAsync(buffered, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Scanner threw for attachment {AttachmentId}",
                 attachmentId);
             attachment.Status = AttachmentStatus.ScanFailed;
             attachment.ScannedAt = DateTimeOffset.UtcNow;

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/MimeSignatureValidator.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/MimeSignatureValidator.cs
@@ -1,0 +1,67 @@
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Hand-rolled magic-byte table for the MIME types the attachment subsystem
+/// accepts (see <c>AttachmentFeatureRules</c>). Dependency-free because the
+/// allowed set is small and stable; no general-purpose MIME detector is
+/// worth the supply-chain footprint for six signatures.
+///
+/// Returns <c>false</c> for any declared content type we don't recognise,
+/// which is intentional — an attachment row should never reach the scanner
+/// with a content type the upload validator didn't pre-approve.
+/// </summary>
+public static class MimeSignatureValidator
+{
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="prefix"/> begins with a byte
+    /// sequence consistent with <paramref name="declaredContentType"/>.
+    /// </summary>
+    public static bool IsConsistent(ReadOnlySpan<byte> prefix, string declaredContentType)
+    {
+        return declaredContentType switch
+        {
+            "application/pdf"  => StartsWith(prefix, "%PDF-"u8),
+            "image/jpeg"       => StartsWith(prefix, JpegSignature),
+            "image/png"        => StartsWith(prefix, PngSignature),
+            "image/webp"       => IsWebp(prefix),
+            "application/msword" => StartsWith(prefix, DocOle2Signature),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                               => IsZipContainer(prefix),
+            _ => false,
+        };
+    }
+
+    private static readonly byte[] JpegSignature = { 0xFF, 0xD8, 0xFF };
+
+    private static readonly byte[] PngSignature =
+        { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+
+    private static readonly byte[] DocOle2Signature =
+        { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
+
+    private static bool IsWebp(ReadOnlySpan<byte> prefix)
+    {
+        // RIFF container: bytes 0..3 = "RIFF", bytes 8..11 = "WEBP". Bytes
+        // 4..7 hold the file-size minus 8 and aren't checked here.
+        if (prefix.Length < 12) return false;
+        return StartsWith(prefix, "RIFF"u8) && StartsWith(prefix[8..], "WEBP"u8);
+    }
+
+    private static bool IsZipContainer(ReadOnlySpan<byte> prefix)
+    {
+        // ZIP local-file / central-directory / spanning-signature headers.
+        // DOCX is always a ZIP; a non-DOCX ZIP would also match here, but
+        // the V2 validator only admits DOCX content types, so the extra
+        // differentiation is wasted work for this phase.
+        if (prefix.Length < 4) return false;
+        return prefix[0] == 0x50
+            && prefix[1] == 0x4B
+            && (prefix[2] == 0x03 || prefix[2] == 0x05 || prefix[2] == 0x07);
+    }
+
+    private static bool StartsWith(ReadOnlySpan<byte> input, ReadOnlySpan<byte> target)
+    {
+        return input.Length >= target.Length
+            && input[..target.Length].SequenceEqual(target);
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/AttachFileToEntityIntegrityTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachFileToEntityIntegrityTests.cs
@@ -1,0 +1,261 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Features.Attachments.AttachFileToEntity;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Phase 2.1 + 2.3 — the attach endpoint is the final choke-point before an
+/// attachment row is linked to its entity. It must NOT trust the client's
+/// declared size / content-type / rule compliance; it must re-check against
+/// storage (HeadObject) and AttachmentFeatureRules. These tests pin that
+/// contract.
+/// </summary>
+public class AttachFileToEntityIntegrityTests
+{
+    [Fact]
+    public async Task Attach_fails_when_no_object_exists_in_storage_for_the_key()
+    {
+        var f = await SeedAsync();
+        var storage = StorageReturning(metadata: null);
+
+        var act = () => RunHandler(f, storage);
+
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage("*not uploaded*");
+    }
+
+    [Fact]
+    public async Task Attach_rejects_when_stored_size_exceeds_max_file_size()
+    {
+        var f = await SeedAsync();
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 11L * 1024 * 1024,
+            ContentType: "application/pdf"));
+
+        var act = () => RunHandler(f, storage);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*exceeds*max*size*");
+    }
+
+    [Fact]
+    public async Task Attach_rejects_when_stored_content_type_differs_from_row()
+    {
+        var f = await SeedAsync();
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 2048,
+            ContentType: "application/x-msdownload"));
+
+        var act = () => RunHandler(f, storage);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*content type*");
+    }
+
+    [Fact]
+    public async Task Attach_reconciles_size_when_stored_size_differs_from_declared()
+    {
+        var f = await SeedAsync(declaredSize: 2048);
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 1536,
+            ContentType: "application/pdf"));
+
+        await RunHandler(f, storage);
+
+        await using var ctx = new AppDbContext(f.Options, f.CurrentUser);
+        var row = await ctx.Attachments.SingleAsync(a => a.Id == f.AttachmentId);
+        row.SizeBytes.Should().Be(1536, "server overwrites declared size with the actual S3 size");
+        row.EntityId.Should().Be(f.HomeworkId);
+    }
+
+    [Fact]
+    public async Task Attach_rejects_when_row_content_type_is_not_allowed_for_entity()
+    {
+        var f = await SeedAsync(
+            declaredContentType: "text/html",
+            declaredFileName: "evil.html");
+
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 2048,
+            ContentType: "text/html"));
+
+        var act = () => RunHandler(f, storage);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not allowed*");
+    }
+
+    [Fact]
+    public async Task Attach_rejects_when_row_file_extension_is_not_allowed_for_entity()
+    {
+        // Extension is .exe, content type pretends to be PDF to pass the
+        // content-type check — the extension rule still blocks it.
+        var f = await SeedAsync(
+            declaredContentType: "application/pdf",
+            declaredFileName: "malware.exe");
+
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 2048,
+            ContentType: "application/pdf"));
+
+        var act = () => RunHandler(f, storage);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*extension*");
+    }
+
+    [Fact]
+    public async Task Attach_happy_path_links_row_and_enqueues_scan()
+    {
+        var f = await SeedAsync();
+        var storage = StorageReturning(new StorageObjectMetadata(
+            SizeBytes: 2048,
+            ContentType: "application/pdf"));
+
+        var queue = new Mock<IAttachmentScanQueue>();
+        queue.Setup(q => q.EnqueueAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        await RunHandler(f, storage, queue: queue);
+
+        await using var ctx = new AppDbContext(f.Options, f.CurrentUser);
+        var row = await ctx.Attachments.SingleAsync(a => a.Id == f.AttachmentId);
+        row.EntityId.Should().Be(f.HomeworkId);
+        row.EntityType.Should().Be("homework");
+        queue.Verify(q => q.EnqueueAsync(f.AttachmentId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Task RunHandler(
+        Fixture f,
+        Mock<IStorageService> storage,
+        Mock<IAttachmentScanQueue>? queue = null)
+    {
+        var queueMock = queue ?? new Mock<IAttachmentScanQueue>();
+        queueMock
+            .Setup(q => q.EnqueueAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var ctx = new AppDbContext(f.Options, f.CurrentUser);
+        var handler = new AttachFileToEntityCommandHandler(
+            ctx,
+            f.CurrentUser,
+            storage.Object,
+            queueMock.Object,
+            Options.Create(new StorageOptions()),
+            NullLogger<AttachFileToEntityCommandHandler>.Instance);
+
+        return handler.Handle(
+            new AttachFileToEntityCommand(f.AttachmentId, f.HomeworkId, "homework"),
+            CancellationToken.None);
+    }
+
+    private static Mock<IStorageService> StorageReturning(StorageObjectMetadata? metadata)
+    {
+        var storage = new Mock<IStorageService>();
+        storage
+            .Setup(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metadata);
+        return storage;
+    }
+
+    private static async Task<Fixture> SeedAsync(
+        int declaredSize = 2048,
+        string declaredContentType = "application/pdf",
+        string declaredFileName = "worksheet.pdf")
+    {
+        var schoolId = Guid.NewGuid();
+        var classId = Guid.NewGuid();
+        var teacherId = Guid.NewGuid();
+        var homeworkId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"AttachIntegrity_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        var currentUser = new CurrentUserService
+        {
+            SchoolId = schoolId,
+            UserId = teacherId,
+            Role = "Teacher",
+            Name = "Teacher",
+        };
+
+        await using (var ctx = new AppDbContext(options, currentUser))
+        {
+            ctx.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId,
+                Name = "Test School",
+                Code = "T1",
+                Address = "",
+                ContactPhone = "",
+                ContactEmail = "",
+            });
+            ctx.Classes.Add(new ClassEntity
+            {
+                Id = classId,
+                SchoolId = schoolId,
+                Name = "7",
+                Section = "A",
+                AcademicYear = "2026",
+            });
+            ctx.Users.Add(new UserEntity
+            {
+                Id = teacherId,
+                SchoolId = schoolId,
+                Phone = "09000000010",
+                Name = "Teacher",
+                Role = "Teacher",
+            });
+            ctx.Homeworks.Add(new HomeworkEntity
+            {
+                Id = homeworkId,
+                SchoolId = schoolId,
+                ClassId = classId,
+                Subject = "Math",
+                Title = "HW",
+                Description = "",
+                AssignedById = teacherId,
+                DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(3)),
+                Status = "Draft",
+            });
+            ctx.Attachments.Add(new AttachmentEntity
+            {
+                Id = attachmentId,
+                SchoolId = schoolId,
+                EntityId = null,
+                EntityType = "homework",
+                StorageKey = $"{schoolId}/homework/{attachmentId}-{declaredFileName}",
+                FileName = declaredFileName,
+                ContentType = declaredContentType,
+                SizeBytes = declaredSize,
+                UploadedById = teacherId,
+                UploadedAt = DateTimeOffset.UtcNow,
+                Status = AttachmentStatus.Pending,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        return new Fixture(options, currentUser, attachmentId, homeworkId);
+    }
+
+    private sealed record Fixture(
+        DbContextOptions<AppDbContext> Options,
+        CurrentUserService CurrentUser,
+        Guid AttachmentId,
+        Guid HomeworkId);
+}

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentMagicByteTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentMagicByteTests.cs
@@ -1,0 +1,290 @@
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Phase 2.4 — the scan worker peeks the first bytes of every uploaded
+/// object and compares against <see cref="MimeSignatureValidator"/> before
+/// handing the body to ClamAV. A file with a declared MIME that doesn't
+/// match its actual bytes (e.g. a PE renamed .pdf) is marked Infected with
+/// ThreatName="MIME_MISMATCH" and removed from storage.
+/// </summary>
+public class AttachmentMagicByteTests
+{
+    // ── signature table unit tests ──────────────────────────────────────
+
+    public static IEnumerable<object[]> ConsistentSamples => new[]
+    {
+        new object[] { Bytes("%PDF-1.7\n"), "application/pdf" },
+        new object[] { Bytes(0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10), "image/jpeg" },
+        new object[] { Bytes(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A), "image/png" },
+        new object[]
+        {
+            Concat(Bytes("RIFF"), Bytes(0x00, 0x00, 0x00, 0x00), Bytes("WEBP")),
+            "image/webp",
+        },
+        new object[]
+        {
+            Bytes(0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1),
+            "application/msword",
+        },
+        new object[]
+        {
+            Bytes(0x50, 0x4B, 0x03, 0x04, 0x14, 0x00),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(ConsistentSamples))]
+    public void IsConsistent_returns_true_for_matching_prefix(byte[] prefix, string declaredContentType)
+    {
+        MimeSignatureValidator.IsConsistent(prefix, declaredContentType).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsConsistent_returns_false_when_pdf_prefix_is_actually_png()
+    {
+        var pngBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        MimeSignatureValidator.IsConsistent(pngBytes, "application/pdf").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConsistent_returns_false_for_unknown_declared_content_type()
+    {
+        var pdfBytes = Bytes("%PDF-");
+        MimeSignatureValidator.IsConsistent(pdfBytes, "application/x-msdownload").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConsistent_returns_false_for_empty_prefix()
+    {
+        MimeSignatureValidator.IsConsistent(ReadOnlySpan<byte>.Empty, "application/pdf").Should().BeFalse();
+    }
+
+    // ── worker integration: MIME_MISMATCH path ──────────────────────────
+
+    [Fact]
+    public async Task Worker_marks_attachment_Infected_when_magic_bytes_dont_match_declared_content_type()
+    {
+        var schoolId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"MimeMismatch_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        await using (var seed = new AppDbContext(options))
+        {
+            seed.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId,
+                Name = "School",
+                Code = "X",
+                Address = "",
+                ContactPhone = "",
+                ContactEmail = "",
+            });
+            seed.Attachments.Add(new AttachmentEntity
+            {
+                Id = attachmentId,
+                SchoolId = schoolId,
+                EntityType = "homework",
+                StorageKey = "school/homework/fake.pdf",
+                FileName = "fake.pdf",
+                ContentType = "application/pdf",
+                SizeBytes = 8,
+                UploadedById = Guid.NewGuid(),
+                UploadedAt = DateTimeOffset.UtcNow,
+                Status = AttachmentStatus.Pending,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        // Bytes don't start with %PDF-; declared application/pdf will
+        // trip the magic-byte pre-check.
+        var adversarialBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00 };
+
+        var storage = new Mock<IStorageService>();
+        storage
+            .Setup(s => s.OpenObjectReadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(adversarialBytes));
+        storage
+            .Setup(s => s.DeleteObjectAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var scanner = new Mock<IAttachmentScanner>(MockBehavior.Strict);
+        // Scanner must NEVER be called for a MIME mismatch — the
+        // pre-check rejects the file first.
+
+        var scopeFactory = new SharedOptionsScopeFactory(storage.Object, scanner.Object, options);
+
+        var worker = new AttachmentScanWorker(
+            scopeFactory,
+            new ChannelAttachmentScanQueue(),
+            NullLogger<AttachmentScanWorker>.Instance);
+
+        await worker.ScanOneAsync(attachmentId, CancellationToken.None);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.Infected);
+        row.ThreatName.Should().Be("MIME_MISMATCH");
+        row.ScannedAt.Should().NotBeNull();
+
+        storage.Verify(
+            s => s.DeleteObjectAsync("school/homework/fake.pdf", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Worker_passes_content_to_scanner_when_magic_bytes_match()
+    {
+        var schoolId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"MimeMatch_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        await using (var seed = new AppDbContext(options))
+        {
+            seed.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId,
+                Name = "School",
+                Code = "Y",
+                Address = "",
+                ContactPhone = "",
+                ContactEmail = "",
+            });
+            seed.Attachments.Add(new AttachmentEntity
+            {
+                Id = attachmentId,
+                SchoolId = schoolId,
+                EntityType = "homework",
+                StorageKey = "school/homework/real.pdf",
+                FileName = "real.pdf",
+                ContentType = "application/pdf",
+                SizeBytes = 9,
+                UploadedById = Guid.NewGuid(),
+                UploadedAt = DateTimeOffset.UtcNow,
+                Status = AttachmentStatus.Pending,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var pdfBytes = System.Text.Encoding.ASCII.GetBytes("%PDF-1.7\n");
+
+        var storage = new Mock<IStorageService>();
+        storage
+            .Setup(s => s.OpenObjectReadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(pdfBytes));
+
+        var scanner = new Mock<IAttachmentScanner>();
+        scanner
+            .Setup(s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ScanResult(ScanVerdict.Clean, "mock"));
+
+        var scopeFactory = new SharedOptionsScopeFactory(storage.Object, scanner.Object, options);
+
+        var worker = new AttachmentScanWorker(
+            scopeFactory,
+            new ChannelAttachmentScanQueue(),
+            NullLogger<AttachmentScanWorker>.Instance);
+
+        await worker.ScanOneAsync(attachmentId, CancellationToken.None);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.Available);
+        row.ThreatName.Should().BeNull();
+
+        scanner.Verify(
+            s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static byte[] Bytes(string ascii) => System.Text.Encoding.ASCII.GetBytes(ascii);
+    private static byte[] Bytes(params byte[] bytes) => bytes;
+    private static byte[] Concat(params byte[][] chunks)
+    {
+        var total = chunks.Sum(c => c.Length);
+        var result = new byte[total];
+        var offset = 0;
+        foreach (var c in chunks)
+        {
+            Buffer.BlockCopy(c, 0, result, offset, c.Length);
+            offset += c.Length;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IServiceScopeFactory"/> that hands the worker
+    /// the mocks plus a fresh <see cref="AppDbContext"/> pointing at the
+    /// seeded in-memory database on every call.
+    /// </summary>
+    private sealed class SharedOptionsScopeFactory : IServiceScopeFactory
+    {
+        private readonly IStorageService _storage;
+        private readonly IAttachmentScanner _scanner;
+        private readonly DbContextOptions<AppDbContext> _options;
+
+        public SharedOptionsScopeFactory(
+            IStorageService storage,
+            IAttachmentScanner scanner,
+            DbContextOptions<AppDbContext> options)
+        {
+            _storage = storage;
+            _scanner = scanner;
+            _options = options;
+        }
+
+        public IServiceScope CreateScope() => new Scope(_storage, _scanner, _options);
+
+        private sealed class Scope : IServiceScope, IServiceProvider
+        {
+            private readonly IStorageService _storage;
+            private readonly IAttachmentScanner _scanner;
+            private readonly DbContextOptions<AppDbContext> _options;
+            private AppDbContext? _ctx;
+
+            public Scope(IStorageService storage, IAttachmentScanner scanner, DbContextOptions<AppDbContext> options)
+            {
+                _storage = storage;
+                _scanner = scanner;
+                _options = options;
+            }
+
+            public IServiceProvider ServiceProvider => this;
+
+            public object? GetService(Type serviceType)
+            {
+                if (serviceType == typeof(IStorageService)) return _storage;
+                if (serviceType == typeof(IAttachmentScanner)) return _scanner;
+                if (serviceType == typeof(AppDbContext))
+                {
+                    _ctx ??= new AppDbContext(_options);
+                    return _ctx;
+                }
+                return null;
+            }
+
+            public void Dispose() => _ctx?.Dispose();
+        }
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
@@ -71,6 +71,7 @@ public class HomeworkAttachmentFlowTests
             .Setup(service => service.GeneratePresignedUploadUrlAsync(
                 It.IsAny<string>(),
                 "application/pdf",
+                2048L,
                 It.IsAny<TimeSpan>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("https://upload.example.com");


### PR DESCRIPTION
Four coordinated P0 fixes that close the "client told us the truth" gap. The attach endpoint and scan worker are now the authoritative source for size, content type, and declared-vs-actual MIME consistency.

2.1 HeadObject on attach. IStorageService gains GetObjectMetadataAsync
    (S3StorageService uses HeadObjectAsync, catches 404 → null).
    AttachFileToEntityCommandHandler now refuses to link a row if the
    object doesn't exist, if its size exceeds MaxFileSizeBytes, or if
    the stored Content-Type differs from the declared one. Size
    mismatches reconcile silently (log at Warning) — the DB row
    becomes the source of truth for the actual byte count.

2.2 Content-Length pinned at sign time. GeneratePresignedUploadUrlAsync
    now takes sizeBytes and signs the PUT with Content-Length in the
    request headers, so S3 / R2 / MinIO reject uploads whose body size
    differs. Both V1 and V2 upload handlers updated; matching mock in
    HomeworkAttachmentFlowTests updated to include the new arg.

2.3 AttachmentRules re-checked at attach. The V2 validator already
    enforces allowed content-type + extension per entity type, but
    attach is the last line of defence — a V1 row or a row prepared
    for a different entity type must still be rejected here.

2.4 Magic-byte pre-scan in AttachmentScanWorker. New
    MimeSignatureValidator (hand-rolled table for PDF/JPEG/PNG/WEBP/
    DOC/DOCX — six signatures; no supply-chain dependency). The
    worker buffers the object into memory, peeks the first 64 bytes,
    and on mismatch marks the attachment Infected with
    ThreatName="MIME_MISMATCH" and deletes from storage before
    ClamAV ever sees it. The 10 MB file cap keeps memory bounded.

Scope-local change: AttachmentScanWorker.ScanOneAsync moved from private to internal + InternalsVisibleTo(EduConnect.Api.Tests) so the magic-byte integration path can be asserted end-to-end without a brittle timing loop around the background service.

Tests (red-first for every security branch):
- AttachFileToEntityIntegrityTests — 7 cases: HeadObject null → 404, oversize → 400, CT mismatch → 400, size reconcile, row-CT rule rejection, row-extension rule rejection, happy path.
- AttachmentMagicByteTests — 11 cases: 6 consistent-prefix theories, PDF/PNG mismatch, unknown CT, empty prefix, worker MIME_MISMATCH path, worker happy path.

Suite: 114 passed, 2 pre-existing AdminOnboarding failures unchanged.