### PR TITLE
feat(api): Phase 3 — scan-queue durability (P1)

### DIFF
--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanQueue.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanQueue.cs
@@ -7,6 +7,28 @@ namespace EduConnect.Api.Infrastructure.Services.Scanning;
 /// only: if we ever horizontally scale the API, this needs to move to a
 /// durable queue (Redis/PG LISTEN). The Channel is bounded so a burst of
 /// uploads can't blow up heap — backpressure falls on the enqueuer.
+///
+/// Durability model — accepted design as of Phase 3 remediation
+/// (2026-04-22):
+///   This queue is volatile. The attach handler commits the
+///   attachment row with Status=Pending and then enqueues the ID in a
+///   second step (no transactional outbox). A crash between those two
+///   operations leaves a Pending row with no queued job.
+///
+///   Recovery path: <see cref="AttachmentScanReconciler"/> runs at
+///   host startup and re-enqueues every Pending row older than the
+///   configured grace window
+///   (<see cref="AttachmentScannerOptions.ReconciliationGraceMinutes"/>,
+///   default 2 min). The worker's "skip non-Pending" guard makes the
+///   re-enqueue idempotent against still-running attach calls.
+///
+///   This is the lightweight alternative to a real outbox table. We
+///   accept a recovery window in exchange for not maintaining a
+///   second persisted queue. If reconciliation counts ever grow past
+///   a handful of rows per restart, escalate by introducing a
+///   transactional outbox (commit ID into outbox in the same
+///   transaction as the attachment row, separate dispatcher process
+///   reads-and-acks).
 /// </summary>
 public interface IAttachmentScanQueue
 {

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanReconciler.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanReconciler.cs
@@ -1,0 +1,88 @@
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Recovers attachment scan jobs that were lost across a restart. The
+/// in-memory queue (<see cref="ChannelAttachmentScanQueue"/>) is volatile,
+/// so any row that was enqueued but not scanned before shutdown sits in
+/// the database with <c>Status = Pending</c> and never progresses unless
+/// something re-enqueues it.
+///
+/// Runs once on host startup, before <see cref="AttachmentScanWorker"/>
+/// begins draining new uploads. Scoped DbContext so we don't hold one
+/// open for the lifetime of the host. RLS-bypass via
+/// <c>IgnoreQueryFilters</c> for the same reason as the worker — there
+/// is no tenant context in a startup hook.
+///
+/// This is the lightweight alternative to a transactional outbox table:
+/// it accepts a small recovery window (the grace period) instead of
+/// closing the commit-vs-enqueue race entirely. If observed reconciler
+/// counts grow beyond a handful per restart, escalate to a real outbox.
+/// </summary>
+public sealed class AttachmentScanReconciler : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAttachmentScanQueue _queue;
+    private readonly AttachmentScannerOptions _options;
+    private readonly ILogger<AttachmentScanReconciler> _logger;
+
+    public AttachmentScanReconciler(
+        IServiceScopeFactory scopeFactory,
+        IAttachmentScanQueue queue,
+        IOptions<AttachmentScannerOptions> options,
+        ILogger<AttachmentScanReconciler> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _queue = queue;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var count = await ReconcileAsync(cancellationToken);
+            _logger.LogInformation(
+                "AttachmentScanReconciler completed: {Count} stale Pending attachment(s) re-enqueued",
+                count);
+        }
+        catch (Exception ex)
+        {
+            // Reconciler failure must not block host startup. The worker
+            // will still drain new uploads; an operator can re-trigger
+            // reconciliation later (or restart again).
+            _logger.LogError(ex,
+                "AttachmentScanReconciler failed during startup; continuing without recovered jobs");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    internal async Task<int> ReconcileAsync(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var graceMinutes = Math.Max(0, _options.ReconciliationGraceMinutes);
+        var threshold = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(graceMinutes);
+
+        var staleIds = await db.Attachments
+            .IgnoreQueryFilters()
+            .Where(a => a.Status == AttachmentStatus.Pending && a.UploadedAt < threshold)
+            .Select(a => a.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var id in staleIds)
+        {
+            await _queue.EnqueueAsync(id, cancellationToken);
+        }
+
+        return staleIds.Count;
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using EduConnect.Api.Infrastructure.Database;
 using EduConnect.Api.Infrastructure.Database.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -18,18 +19,39 @@ namespace EduConnect.Api.Infrastructure.Services.Scanning;
 /// </summary>
 public sealed class AttachmentScanWorker : BackgroundService
 {
+    // Total scan attempts on transient I/O failures (network blip, daemon
+    // restart, request timeout). 3 attempts with 2/4s back-offs covers the
+    // typical clamd restart window without unduly stalling other jobs.
+    internal const int MaxScanAttempts = 3;
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IAttachmentScanQueue _queue;
     private readonly ILogger<AttachmentScanWorker> _logger;
+    private readonly Func<int, TimeSpan> _retryBackoff;
 
     public AttachmentScanWorker(
         IServiceScopeFactory scopeFactory,
         IAttachmentScanQueue queue,
         ILogger<AttachmentScanWorker> logger)
+        : this(scopeFactory, queue, logger,
+            // Exponential back-off: 2s after the 1st failure, 4s after the
+            // 2nd, never reached after the 3rd (loop exits).
+            attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)))
+    {
+    }
+
+    // Internal ctor lets tests inject a zero back-off so they don't sit
+    // through 6+ seconds of Task.Delay per retry exhaustion case.
+    internal AttachmentScanWorker(
+        IServiceScopeFactory scopeFactory,
+        IAttachmentScanQueue queue,
+        ILogger<AttachmentScanWorker> logger,
+        Func<int, TimeSpan> retryBackoff)
     {
         _scopeFactory = scopeFactory;
         _queue = queue;
         _logger = logger;
+        _retryBackoff = retryBackoff;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -145,17 +167,55 @@ public sealed class AttachmentScanWorker : BackgroundService
             return;
         }
 
-        ScanResult result;
-        try
+        ScanResult? result = null;
+        Exception? lastTransientFailure = null;
+        for (var attempt = 1; attempt <= MaxScanAttempts; attempt++)
         {
-            result = await scanner.ScanAsync(buffered, ct);
+            try
+            {
+                buffered.Position = 0;
+                result = await scanner.ScanAsync(buffered, ct);
+                lastTransientFailure = null;
+                break;
+            }
+            catch (Exception ex) when (IsTransientScannerFailure(ex))
+            {
+                lastTransientFailure = ex;
+                if (attempt == MaxScanAttempts) break;
+
+                var backoff = _retryBackoff(attempt);
+                _logger.LogWarning(ex,
+                    "Scanner transient failure (attempt {Attempt}/{Max}) for {AttachmentId}; retrying in {DelaySeconds}s",
+                    attempt, MaxScanAttempts, attachmentId, backoff.TotalSeconds);
+                await Task.Delay(backoff, ct);
+            }
+            catch (Exception ex)
+            {
+                // Non-transient (e.g. parse / protocol bug) — no point retrying.
+                _logger.LogError(ex,
+                    "Scanner failed (non-transient) for attachment {AttachmentId}",
+                    attachmentId);
+                attachment.Status = AttachmentStatus.ScanFailed;
+                attachment.ThreatName = ex.GetType().Name;
+                attachment.ScannedAt = DateTimeOffset.UtcNow;
+                await db.SaveChangesAsync(ct);
+                return;
+            }
         }
-        catch (Exception ex)
+
+        if (result is null)
         {
-            _logger.LogError(ex,
-                "Scanner threw for attachment {AttachmentId}",
-                attachmentId);
+            _logger.LogError(lastTransientFailure,
+                "Scanner failed after {Max} transient retries for attachment {AttachmentId}",
+                MaxScanAttempts, attachmentId);
             attachment.Status = AttachmentStatus.ScanFailed;
+            attachment.ThreatName = lastTransientFailure switch
+            {
+                TimeoutException   => "scan_timeout",
+                SocketException    => "scanner_unreachable",
+                IOException        => "scanner_io_error",
+                _                  => lastTransientFailure?.GetType().Name ?? "unknown",
+            };
             attachment.ScannedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync(ct);
             return;
@@ -163,21 +223,22 @@ public sealed class AttachmentScanWorker : BackgroundService
 
         attachment.ScannedAt = DateTimeOffset.UtcNow;
 
-        if (result.IsClean)
+        var verdict = result;
+        if (verdict.IsClean)
         {
             attachment.Status = AttachmentStatus.Available;
             _logger.LogInformation(
                 "Attachment {AttachmentId} cleared by {Engine}",
-                attachmentId, result.Engine);
+                attachmentId, verdict.Engine);
         }
-        else if (result.IsInfected)
+        else if (verdict.IsInfected)
         {
             attachment.Status = AttachmentStatus.Infected;
-            attachment.ThreatName = result.ThreatName;
+            attachment.ThreatName = verdict.ThreatName;
 
             _logger.LogWarning(
                 "Attachment {AttachmentId} flagged as infected by {Engine}: {Threat}. Deleting from storage.",
-                attachmentId, result.Engine, result.ThreatName);
+                attachmentId, verdict.Engine, verdict.ThreatName);
 
             try
             {
@@ -194,12 +255,20 @@ public sealed class AttachmentScanWorker : BackgroundService
         else
         {
             attachment.Status = AttachmentStatus.ScanFailed;
-            attachment.ThreatName = result.ThreatName;
+            attachment.ThreatName = verdict.ThreatName;
             _logger.LogError(
                 "Attachment {AttachmentId} scan failed via {Engine}: {Detail}",
-                attachmentId, result.Engine, result.ThreatName);
+                attachmentId, verdict.Engine, verdict.ThreatName);
         }
 
         await db.SaveChangesAsync(ct);
     }
+
+    // Transient = "the scanner could not be reached or didn't reply in
+    // time." Things like a malformed protocol response are not retried
+    // (separate catch in the retry loop) since they indicate a bug.
+    private static bool IsTransientScannerFailure(Exception ex) =>
+        ex is SocketException
+            or IOException
+            or TimeoutException;
 }

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/ClamAvAttachmentScanner.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/ClamAvAttachmentScanner.cs
@@ -82,17 +82,30 @@ public sealed class ClamAvAttachmentScanner : IAttachmentScanner
 
             return ParseReply(replyBuilder.ToString().Trim('\0', ' ', '\n', '\r'));
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _logger.LogError("ClamAV scan timed out after {Timeout}s against {Host}:{Port}",
+            // Caller cancellation — propagate so the worker can shut down
+            // cleanly without the scanner masking the cancellation as an
+            // Error verdict.
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            // Internal timeout (linked CTS fired). Surface as a typed
+            // TimeoutException so the worker's retry loop can recognise
+            // it as transient.
+            _logger.LogWarning(
+                "ClamAV scan timed out after {Timeout}s against {Host}:{Port}",
                 _options.TimeoutSeconds, _options.Host, _options.Port);
-            return new ScanResult(ScanVerdict.Error, EngineName, "scan_timeout");
+            throw new TimeoutException(
+                $"ClamAV scan timed out after {_options.TimeoutSeconds}s against {_options.Host}:{_options.Port}",
+                ex);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "ClamAV scan failed against {Host}:{Port}", _options.Host, _options.Port);
-            return new ScanResult(ScanVerdict.Error, EngineName, ex.GetType().Name);
-        }
+        // SocketException, IOException and any other I/O failure
+        // propagate to the caller. The worker's retry loop classifies
+        // them as transient (worth a retry) or terminal (mark
+        // ScanFailed). Catching them here would deny the worker the
+        // chance to retry across a transient blip.
     }
 
     private ScanResult ParseReply(string reply)

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentScanner.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentScanner.cs
@@ -36,4 +36,13 @@ public sealed class AttachmentScannerOptions
     public string Host { get; set; } = "clamav";
     public int Port { get; set; } = 3310;
     public int TimeoutSeconds { get; set; } = 30;
+
+    // Grace window used by AttachmentScanReconciler to decide which
+    // Pending rows to re-enqueue at startup. Rows newer than this are
+    // skipped so we don't double-enqueue an attachment that's still in
+    // the middle of an attach handler call. The handler's enqueue is
+    // idempotent (the worker early-returns on non-Pending status), so
+    // overshooting is safe — undershooting (too long a window) just
+    // means longer recovery after a crash.
+    public int ReconciliationGraceMinutes { get; set; } = 2;
 }

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -180,6 +180,9 @@ EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerRegistration.Ad
     builder.Environment);
 builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentScanQueue,
     EduConnect.Api.Infrastructure.Services.Scanning.ChannelAttachmentScanQueue>();
+// Reconciler runs first so any stale Pending rows from a prior crash are
+// in the queue before the worker starts draining new uploads.
+builder.Services.AddHostedService<EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScanReconciler>();
 builder.Services.AddHostedService<EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScanWorker>();
 
 builder.Services.AddHttpContextAccessor();

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanReconcilerTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanReconcilerTests.cs
@@ -1,0 +1,240 @@
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Phase 3.1 — the reconciler runs at host startup and re-enqueues any
+/// attachment that's still <c>Pending</c> from before a restart, so the
+/// volatile in-memory queue doesn't silently lose work.
+/// </summary>
+public class AttachmentScanReconcilerTests
+{
+    [Fact]
+    public async Task Reconciler_re_enqueues_pending_attachments_older_than_grace_window()
+    {
+        var schoolId = Guid.NewGuid();
+        var staleId = Guid.NewGuid();
+
+        var options = NewOptions();
+        await SeedAsync(options, schoolId, attachments:
+        [
+            BuildAttachment(staleId, schoolId, AttachmentStatus.Pending, uploadedAt: DateTimeOffset.UtcNow.AddMinutes(-10)),
+        ]);
+
+        var queue = new ChannelAttachmentScanQueue();
+        var reconciler = NewReconciler(options, queue, graceMinutes: 2);
+
+        var count = await reconciler.ReconcileAsync(CancellationToken.None);
+
+        count.Should().Be(1);
+        var dequeued = await DequeueOneAsync(queue);
+        dequeued.Should().Be(staleId);
+    }
+
+    [Fact]
+    public async Task Reconciler_skips_pending_attachments_within_grace_window()
+    {
+        var schoolId = Guid.NewGuid();
+        var freshId = Guid.NewGuid();
+
+        var options = NewOptions();
+        await SeedAsync(options, schoolId, attachments:
+        [
+            BuildAttachment(freshId, schoolId, AttachmentStatus.Pending, uploadedAt: DateTimeOffset.UtcNow),
+        ]);
+
+        var queue = new ChannelAttachmentScanQueue();
+        var reconciler = NewReconciler(options, queue, graceMinutes: 2);
+
+        var count = await reconciler.ReconcileAsync(CancellationToken.None);
+
+        count.Should().Be(0);
+        (await IsQueueEmptyAsync(queue)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reconciler_skips_attachments_already_in_terminal_states()
+    {
+        var schoolId = Guid.NewGuid();
+        var available = Guid.NewGuid();
+        var infected = Guid.NewGuid();
+        var failed = Guid.NewGuid();
+
+        var options = NewOptions();
+        var oldUploadedAt = DateTimeOffset.UtcNow.AddMinutes(-10);
+        await SeedAsync(options, schoolId, attachments:
+        [
+            BuildAttachment(available, schoolId, AttachmentStatus.Available, uploadedAt: oldUploadedAt),
+            BuildAttachment(infected,  schoolId, AttachmentStatus.Infected,  uploadedAt: oldUploadedAt),
+            BuildAttachment(failed,    schoolId, AttachmentStatus.ScanFailed, uploadedAt: oldUploadedAt),
+        ]);
+
+        var queue = new ChannelAttachmentScanQueue();
+        var reconciler = NewReconciler(options, queue, graceMinutes: 2);
+
+        var count = await reconciler.ReconcileAsync(CancellationToken.None);
+
+        count.Should().Be(0);
+        (await IsQueueEmptyAsync(queue)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reconciler_works_across_multiple_tenants_via_RLS_bypass()
+    {
+        var schoolA = Guid.NewGuid();
+        var schoolB = Guid.NewGuid();
+        var rowA = Guid.NewGuid();
+        var rowB = Guid.NewGuid();
+
+        var options = NewOptions();
+        var oldUploadedAt = DateTimeOffset.UtcNow.AddMinutes(-10);
+        await SeedAsync(options, schoolA, attachments:
+        [
+            BuildAttachment(rowA, schoolA, AttachmentStatus.Pending, uploadedAt: oldUploadedAt),
+        ]);
+        await SeedAsync(options, schoolB, attachments:
+        [
+            BuildAttachment(rowB, schoolB, AttachmentStatus.Pending, uploadedAt: oldUploadedAt),
+        ]);
+
+        var queue = new ChannelAttachmentScanQueue();
+        var reconciler = NewReconciler(options, queue, graceMinutes: 2);
+
+        var count = await reconciler.ReconcileAsync(CancellationToken.None);
+
+        count.Should().Be(2);
+        var first = await DequeueOneAsync(queue);
+        var second = await DequeueOneAsync(queue);
+        new[] { first, second }.Should().BeEquivalentTo(new[] { rowA, rowB });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"Reconciler_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private static AttachmentScanReconciler NewReconciler(
+        DbContextOptions<AppDbContext> options,
+        IAttachmentScanQueue queue,
+        int graceMinutes)
+    {
+        return new AttachmentScanReconciler(
+            new SingleScopeFactory(options),
+            queue,
+            Options.Create(new AttachmentScannerOptions { ReconciliationGraceMinutes = graceMinutes }),
+            NullLogger<AttachmentScanReconciler>.Instance);
+    }
+
+    private static async Task SeedAsync(
+        DbContextOptions<AppDbContext> options,
+        Guid schoolId,
+        IEnumerable<AttachmentEntity>? attachments = null)
+    {
+        await using var ctx = new AppDbContext(options);
+        if (!await ctx.Schools.AnyAsync(s => s.Id == schoolId))
+        {
+            ctx.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId,
+                Name = "S",
+                Code = $"S-{schoolId.ToString()[..6]}",
+                Address = "",
+                ContactPhone = "",
+                ContactEmail = "",
+            });
+        }
+        if (attachments is not null)
+        {
+            ctx.Attachments.AddRange(attachments);
+        }
+        await ctx.SaveChangesAsync();
+    }
+
+    private static AttachmentEntity BuildAttachment(
+        Guid id,
+        Guid schoolId,
+        string status,
+        DateTimeOffset uploadedAt) =>
+        new()
+        {
+            Id = id,
+            SchoolId = schoolId,
+            EntityType = "homework",
+            StorageKey = $"{schoolId}/{id}",
+            FileName = "f.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 1,
+            UploadedById = Guid.NewGuid(),
+            UploadedAt = uploadedAt,
+            Status = status,
+        };
+
+    private static async Task<Guid> DequeueOneAsync(IAttachmentScanQueue queue)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await foreach (var id in queue.DequeueAllAsync(cts.Token))
+        {
+            return id;
+        }
+        throw new InvalidOperationException("queue had no items");
+    }
+
+    private static async Task<bool> IsQueueEmptyAsync(IAttachmentScanQueue queue)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
+        try
+        {
+            await foreach (var _ in queue.DequeueAllAsync(cts.Token))
+            {
+                return false;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Hands out a fresh AppDbContext per scope so the reconciler's
+    /// CreateAsyncScope contract is honoured against the same in-memory
+    /// backing store.
+    /// </summary>
+    private sealed class SingleScopeFactory : IServiceScopeFactory
+    {
+        private readonly DbContextOptions<AppDbContext> _options;
+        public SingleScopeFactory(DbContextOptions<AppDbContext> options) => _options = options;
+        public IServiceScope CreateScope() => new Scope(_options);
+
+        private sealed class Scope : IServiceScope, IServiceProvider
+        {
+            private readonly DbContextOptions<AppDbContext> _options;
+            private AppDbContext? _ctx;
+            public Scope(DbContextOptions<AppDbContext> options) => _options = options;
+            public IServiceProvider ServiceProvider => this;
+            public object? GetService(Type serviceType)
+            {
+                if (serviceType == typeof(AppDbContext))
+                {
+                    _ctx ??= new AppDbContext(_options);
+                    return _ctx;
+                }
+                return null;
+            }
+            public void Dispose() => _ctx?.Dispose();
+        }
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanRetryTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanRetryTests.cs
@@ -1,0 +1,225 @@
+using System.Net.Sockets;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Phase 3.2 — the worker retries the scanner on transient I/O failures
+/// (SocketException, IOException, TimeoutException) up to three attempts
+/// with exponential back-off, then marks the attachment ScanFailed if
+/// the scanner still won't talk. Non-transient failures fail closed
+/// immediately. Tests pass a zero back-off so they don't sit through
+/// the production 2/4-second waits.
+/// </summary>
+public class AttachmentScanRetryTests
+{
+    [Fact]
+    public async Task Worker_recovers_from_transient_socket_failure_and_marks_Available()
+    {
+        var (options, attachmentId) = await SeedPendingAttachmentAsync();
+
+        var calls = 0;
+        var scanner = new Mock<IAttachmentScanner>();
+        scanner
+            .Setup(s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns<Stream, CancellationToken>((_, _) =>
+            {
+                calls++;
+                if (calls < 3)
+                {
+                    throw new SocketException();
+                }
+                return Task.FromResult(new ScanResult(ScanVerdict.Clean, "mock"));
+            });
+
+        await RunWorker(options, scanner.Object);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.Available);
+        row.ThreatName.Should().BeNull();
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Worker_marks_ScanFailed_with_scanner_unreachable_after_three_socket_failures()
+    {
+        var (options, attachmentId) = await SeedPendingAttachmentAsync();
+
+        var scanner = new Mock<IAttachmentScanner>();
+        scanner
+            .Setup(s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SocketException());
+
+        await RunWorker(options, scanner.Object);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.ScanFailed);
+        row.ThreatName.Should().Be("scanner_unreachable");
+        scanner.Verify(
+            s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(AttachmentScanWorker.MaxScanAttempts));
+    }
+
+    [Fact]
+    public async Task Worker_marks_ScanFailed_with_scan_timeout_after_three_TimeoutException_failures()
+    {
+        var (options, attachmentId) = await SeedPendingAttachmentAsync();
+
+        var scanner = new Mock<IAttachmentScanner>();
+        scanner
+            .Setup(s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("clamd timed out"));
+
+        await RunWorker(options, scanner.Object);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.ScanFailed);
+        row.ThreatName.Should().Be("scan_timeout");
+    }
+
+    [Fact]
+    public async Task Worker_does_not_retry_a_non_transient_scanner_failure()
+    {
+        var (options, attachmentId) = await SeedPendingAttachmentAsync();
+
+        var scanner = new Mock<IAttachmentScanner>();
+        scanner
+            .Setup(s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("malformed reply"));
+
+        await RunWorker(options, scanner.Object);
+
+        await using var verify = new AppDbContext(options);
+        var row = await verify.Attachments.SingleAsync(a => a.Id == attachmentId);
+        row.Status.Should().Be(AttachmentStatus.ScanFailed);
+        row.ThreatName.Should().Be("InvalidOperationException");
+        scanner.Verify(
+            s => s.ScanAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static async Task<(DbContextOptions<AppDbContext> Options, Guid AttachmentId)> SeedPendingAttachmentAsync()
+    {
+        var schoolId = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"Retry_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        await using var ctx = new AppDbContext(options);
+        ctx.Schools.Add(new SchoolEntity
+        {
+            Id = schoolId,
+            Name = "School",
+            Code = "R",
+            Address = "",
+            ContactPhone = "",
+            ContactEmail = "",
+        });
+        ctx.Attachments.Add(new AttachmentEntity
+        {
+            Id = attachmentId,
+            SchoolId = schoolId,
+            EntityType = "homework",
+            StorageKey = "school/homework/file.pdf",
+            FileName = "file.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 9,
+            UploadedById = Guid.NewGuid(),
+            UploadedAt = DateTimeOffset.UtcNow,
+            Status = AttachmentStatus.Pending,
+        });
+        await ctx.SaveChangesAsync();
+        return (options, attachmentId);
+    }
+
+    private static async Task RunWorker(
+        DbContextOptions<AppDbContext> options,
+        IAttachmentScanner scanner)
+    {
+        var pdfBytes = System.Text.Encoding.ASCII.GetBytes("%PDF-1.7\n");
+
+        var storage = new Mock<IStorageService>();
+        storage
+            .Setup(s => s.OpenObjectReadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(pdfBytes));
+
+        var worker = new AttachmentScanWorker(
+            new RetryScopeFactory(storage.Object, scanner, options),
+            new ChannelAttachmentScanQueue(),
+            NullLogger<AttachmentScanWorker>.Instance,
+            retryBackoff: _ => TimeSpan.Zero);
+
+        var attachmentId = await new AppDbContext(options).Attachments
+            .Select(a => a.Id)
+            .SingleAsync();
+
+        await worker.ScanOneAsync(attachmentId, CancellationToken.None);
+    }
+
+    private sealed class RetryScopeFactory : IServiceScopeFactory
+    {
+        private readonly IStorageService _storage;
+        private readonly IAttachmentScanner _scanner;
+        private readonly DbContextOptions<AppDbContext> _options;
+
+        public RetryScopeFactory(
+            IStorageService storage,
+            IAttachmentScanner scanner,
+            DbContextOptions<AppDbContext> options)
+        {
+            _storage = storage;
+            _scanner = scanner;
+            _options = options;
+        }
+
+        public IServiceScope CreateScope() => new Scope(_storage, _scanner, _options);
+
+        private sealed class Scope : IServiceScope, IServiceProvider
+        {
+            private readonly IStorageService _storage;
+            private readonly IAttachmentScanner _scanner;
+            private readonly DbContextOptions<AppDbContext> _options;
+            private AppDbContext? _ctx;
+
+            public Scope(IStorageService storage, IAttachmentScanner scanner, DbContextOptions<AppDbContext> options)
+            {
+                _storage = storage;
+                _scanner = scanner;
+                _options = options;
+            }
+
+            public IServiceProvider ServiceProvider => this;
+
+            public object? GetService(Type serviceType)
+            {
+                if (serviceType == typeof(IStorageService)) return _storage;
+                if (serviceType == typeof(IAttachmentScanner)) return _scanner;
+                if (serviceType == typeof(AppDbContext))
+                {
+                    _ctx ??= new AppDbContext(_options);
+                    return _ctx;
+                }
+                return null;
+            }
+
+            public void Dispose() => _ctx?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Three coordinated changes that close the silent-data-loss windows in the attachment scan pipeline.

3.1 Startup reconciler. New AttachmentScanReconciler IHostedService
    runs once at host startup, queries every Pending attachment older
    than AttachmentScannerOptions.ReconciliationGraceMinutes (default
    2 min, configurable), and re-enqueues each ID. Registered before
    AttachmentScanWorker in Program.cs so recovered jobs are in the
    channel before the worker begins draining new uploads. The
    worker's "skip non-Pending" guard makes the re-enqueue idempotent
    against still-running attach calls. Reconciler failures are
    logged at Error and do not block host startup.

3.2 Scanner retry on transient I/O failures. ClamAvAttachmentScanner
    no longer swallows SocketException / IOException — those
    propagate so the worker can retry. Internal timeouts are
    surfaced as TimeoutException (still typed). The worker wraps
    scanner.ScanAsync in a 3-attempt loop with exponential back-off
    (2s, 4s); only SocketException, IOException, TimeoutException
    are retried. Other exceptions (parse / protocol bugs) fail
    closed immediately. Final ScanFailed rows record a typed
    ThreatName: scanner_unreachable / scan_timeout / scanner_io_error
    so operators can distinguish causes.

    Internal ctor on AttachmentScanWorker accepts a back-off Func
    so tests inject TimeSpan.Zero and don't sit through 6+ seconds
    of Task.Delay per retry-exhaustion case.

3.3 Outbox-equivalent design note. AttachmentScanQueue.cs documents
    the explicit decision to rely on the reconciler instead of a
    transactional outbox table — accepts a small recovery window in
    exchange for not maintaining a second persisted queue.
    Escalation criterion noted: if observed reconciliation counts
    grow past a handful per restart, introduce a real outbox.

Tests (red-first):
- AttachmentScanReconcilerTests — 4 cases: stale Pending re-enqueued, fresh Pending skipped (grace window), terminal-state rows skipped, multi-tenant via RLS bypass.
- AttachmentScanRetryTests — 4 cases: 2 socket failures then Clean → Available, 3 socket failures → ScanFailed/scanner_unreachable, 3 timeouts → ScanFailed/scan_timeout, non-transient → ScanFailed with no retries.

Suite: 134 passed, 2 pre-existing AdminOnboarding failures unchanged.