### PR TITLE
feat(web,api): Phase 4 — frontend + UX parity (P1)

### DIFF
--- a/apps/api/docs/attachment-virus-scanning.md
+++ b/apps/api/docs/attachment-virus-scanning.md
@@ -28,11 +28,12 @@ time).
 
 ```
 Client                          API                            Storage
-  │── POST request-upload-url ──▶│
+  │── POST request-upload-url-v2 ▶│
   │                              │── INSERT attachments (Pending)
-  │◀── presigned PUT URL ────────│
+  │◀── { uploadUrl, attachmentId }│   (no storageKey — client PUTs directly)
   │── PUT file ──────────────────────────────────────────────▶│
   │── POST attach ───────────────▶│
+  │                              │── HeadObject(key) — verify size/type
   │                              │── UPDATE attachments (linked)
   │                              │── ChannelAttachmentScanQueue.Enqueue(id)
   │◀── 200 OK ───────────────────│
@@ -40,14 +41,31 @@ Client                          API                            Storage
                                   │       (worker)              │
                                   │── GetObject(key) ──────────▶│
                                   │◀── stream ──────────────────│
+                                  │── magic-byte pre-check
                                   │── INSTREAM to clamd ──▶ reply
                                   │── UPDATE attachments (Available|Infected|ScanFailed)
                                   │── (if Infected) DeleteObject(key) ─▶│
 ```
 
-Until the worker sets `status=Available`, `GetAttachmentsForEntity`
-refuses to hand out a presigned download URL for the row — so the
-parent-facing download path can never point at an unscanned byte.
+`GetAttachmentsForEntity` only mints a presigned download URL for rows
+with `status=Available` — so the read path can never point at an
+unscanned (or infected) byte. From Phase 4 (frontend UX parity), admins
+and teachers also see Pending and ScanFailed rows in the response (with
+a `null` `downloadUrl`) so the UI can render "scanning…" / "blocked"
+badges; parents and other roles still see only Available rows.
+
+### V2 upload response shape
+
+`POST /api/attachments/request-upload-url-v2` returns:
+
+```json
+{ "uploadUrl": "https://…", "attachmentId": "<guid>" }
+```
+
+There is no `storageKey` field — the client uses the presigned URL
+directly to PUT the file, then references the attachment by
+`attachmentId` when calling `/attach`. The storage key is an
+implementation detail of the API.
 
 ## Deploying ClamAV
 

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQuery.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQuery.cs
@@ -2,10 +2,18 @@ namespace EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
 
 public record GetAttachmentsForEntityQuery(Guid EntityId, string EntityType) : IRequest<List<AttachmentDto>>;
 
+/// <summary>
+/// <see cref="DownloadUrl"/> is non-null only when <see cref="Status"/> is
+/// <c>Available</c>. Pending / ScanFailed rows are exposed to admins +
+/// teachers (so they can see "scanning…" / "blocked" badges) but the
+/// presigned URL is withheld until the scan clears — the read path can
+/// never hand out an unscanned object.
+/// </summary>
 public record AttachmentDto(
     Guid Id,
     string FileName,
     string ContentType,
     int SizeBytes,
-    string DownloadUrl,
-    DateTimeOffset UploadedAt);
+    string? DownloadUrl,
+    DateTimeOffset UploadedAt,
+    string Status);

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
@@ -39,17 +39,29 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
             await EnsureHomeworkSubmissionAccessAsync(request.EntityId, cancellationToken);
         }
 
-        // Phase 5 — only expose attachments that passed the virus scan.
-        // Pending / Infected / ScanFailed rows are filtered out here so no
-        // code path downstream can hand out a presigned URL for an
-        // unscanned (or infected) object. Admin review of blocked
-        // attachments is a follow-up surface.
+        // Status visibility (Phase 4 remediation):
+        //  - Admin / Teacher: see Available + Pending + ScanFailed so the
+        //    UI can show "scanning…" / "blocked" badges. Infected rows
+        //    stay hidden — admins are notified out-of-band (Phase 6).
+        //  - Parent / everyone else: only Available, so a child- or
+        //    parent-facing surface never hints at a scan in progress.
+        // Presigned URLs are only minted for Available rows regardless of
+        // role, so the read path can never hand out an unscanned object.
+        var visibleStatuses = CanViewInProgressScans(_currentUserService.Role)
+            ? new[]
+            {
+                AttachmentStatus.Available,
+                AttachmentStatus.Pending,
+                AttachmentStatus.ScanFailed,
+            }
+            : new[] { AttachmentStatus.Available };
+
         var attachments = await _context.Attachments
             .Where(a =>
                 a.EntityId == request.EntityId &&
                 a.EntityType == request.EntityType &&
                 a.SchoolId == _currentUserService.SchoolId &&
-                a.Status == AttachmentStatus.Available)
+                visibleStatuses.Contains(a.Status))
             .OrderBy(a => a.UploadedAt)
             .ToListAsync(cancellationToken);
 
@@ -57,13 +69,17 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
 
         foreach (var attachment in attachments)
         {
-            var downloadUrl = await _storageService.GeneratePresignedDownloadUrlAsync(
-                attachment.StorageKey,
-                TimeSpan.FromHours(1),
-                attachment.FileName,
-                attachment.ContentType,
-                AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
-                cancellationToken);
+            string? downloadUrl = null;
+            if (attachment.Status == AttachmentStatus.Available)
+            {
+                downloadUrl = await _storageService.GeneratePresignedDownloadUrlAsync(
+                    attachment.StorageKey,
+                    TimeSpan.FromHours(1),
+                    attachment.FileName,
+                    attachment.ContentType,
+                    AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
+                    cancellationToken);
+            }
 
             result.Add(new AttachmentDto(
                 attachment.Id,
@@ -71,11 +87,15 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
                 attachment.ContentType,
                 attachment.SizeBytes,
                 downloadUrl,
-                attachment.UploadedAt));
+                attachment.UploadedAt,
+                attachment.Status));
         }
 
         return result;
     }
+
+    private static bool CanViewInProgressScans(string? role) =>
+        role == "Admin" || role == "Teacher";
 
     private async Task EnsureHomeworkAccessAsync(Guid homeworkId, CancellationToken cancellationToken)
     {

--- a/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Command.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/RequestUploadUrlV2/RequestUploadUrlV2Command.cs
@@ -6,6 +6,9 @@ public record RequestUploadUrlV2Command(
     int SizeBytes,
     string EntityType) : IRequest<RequestUploadUrlV2Response>;
 
+// storageKey intentionally omitted — clients PUT directly to uploadUrl
+// and reference the attachment by AttachmentId when calling /attach.
+// See apps/api/docs/attachment-virus-scanning.md.
 public record RequestUploadUrlV2Response(
     string UploadUrl,
     Guid AttachmentId);

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
@@ -17,7 +17,109 @@ namespace EduConnect.Api.Tests;
 public class AttachmentScanFlowTests
 {
     [Fact]
-    public async Task GetAttachmentsForEntity_filters_out_non_available_rows()
+    public async Task GetAttachmentsForEntity_returns_in_progress_statuses_to_teachers_with_download_url_only_for_Available()
+    {
+        var (options, _, homeworkId, teacherId) = await SeedHomeworkWithAllStatusesAsync();
+        var teacher = new CurrentUserService
+        {
+            SchoolId = (await new AppDbContext(options).Schools.Select(s => s.Id).FirstAsync()),
+            UserId = teacherId,
+            Role = "Teacher",
+            Name = "Teacher",
+        };
+
+        var storage = new Mock<IStorageService>(MockBehavior.Strict);
+        storage.Setup(s => s.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://signed/");
+
+        await using var readContext = new AppDbContext(options, teacher);
+        var handler = new GetAttachmentsForEntityQueryHandler(readContext, teacher, storage.Object);
+
+        var result = await handler.Handle(
+            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
+            CancellationToken.None);
+
+        // Teacher sees Pending + Available + ScanFailed; Infected stays
+        // hidden (admins are notified out-of-band).
+        result.Select(r => r.Status).Should().BeEquivalentTo(new[]
+        {
+            AttachmentStatus.Pending,
+            AttachmentStatus.Available,
+            AttachmentStatus.ScanFailed,
+        });
+
+        // Presigned URL minted only for the Available row — the read path
+        // never hands out an unscanned object even when the badge is shown.
+        result.Single(r => r.Status == AttachmentStatus.Available).DownloadUrl
+            .Should().Be("https://signed/");
+        result.Single(r => r.Status == AttachmentStatus.Pending).DownloadUrl.Should().BeNull();
+        result.Single(r => r.Status == AttachmentStatus.ScanFailed).DownloadUrl.Should().BeNull();
+
+        storage.Verify(
+            s => s.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAttachmentsForEntity_returns_only_Available_to_parents()
+    {
+        var (options, schoolId, homeworkId, teacherId) = await SeedHomeworkWithAllStatusesAsync();
+
+        var parentId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var classId = await new AppDbContext(options).Homeworks
+            .Where(h => h.Id == homeworkId).Select(h => h.ClassId).FirstAsync();
+
+        await using (var ctx = new AppDbContext(options))
+        {
+            ctx.Users.Add(new UserEntity
+            {
+                Id = parentId, SchoolId = schoolId, Phone = "09000000099",
+                Name = "Parent", Role = "Parent",
+            });
+            ctx.Students.Add(new StudentEntity
+            {
+                Id = studentId, SchoolId = schoolId, ClassId = classId,
+                Name = "Child", RollNumber = "001", IsActive = true,
+            });
+            ctx.ParentStudentLinks.Add(new ParentStudentLinkEntity
+            {
+                Id = Guid.NewGuid(), SchoolId = schoolId,
+                ParentId = parentId, StudentId = studentId, Relationship = "parent",
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var parent = new CurrentUserService
+        {
+            SchoolId = schoolId, UserId = parentId, Role = "Parent", Name = "Parent",
+        };
+
+        var storage = new Mock<IStorageService>(MockBehavior.Strict);
+        storage.Setup(s => s.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://signed/");
+
+        await using var readContext = new AppDbContext(options, parent);
+        var handler = new GetAttachmentsForEntityQueryHandler(readContext, parent, storage.Object);
+
+        var result = await handler.Handle(
+            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
+            CancellationToken.None);
+
+        result.Should().ContainSingle(
+            "parents should never see Pending / Infected / ScanFailed rows");
+        result[0].Status.Should().Be(AttachmentStatus.Available);
+        result[0].DownloadUrl.Should().Be("https://signed/");
+    }
+
+    private static async Task<(DbContextOptions<AppDbContext> Options, Guid SchoolId, Guid HomeworkId, Guid TeacherId)>
+        SeedHomeworkWithAllStatusesAsync()
     {
         var schoolId = Guid.NewGuid();
         var classId = Guid.NewGuid();
@@ -29,105 +131,73 @@ public class AttachmentScanFlowTests
             .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
-        var currentUser = new CurrentUserService
+        await using var context = new AppDbContext(options);
+        context.Schools.Add(new SchoolEntity
         {
+            Id = schoolId,
+            Name = "Test School",
+            Code = "TEST",
+            Address = "",
+            ContactPhone = "",
+            ContactEmail = "",
+        });
+        context.Classes.Add(new ClassEntity
+        {
+            Id = classId,
             SchoolId = schoolId,
-            UserId = teacherId,
-            Role = "Teacher",
-            Name = "Test Teacher",
-        };
-
-        await using (var context = new AppDbContext(options, currentUser))
+            Name = "6",
+            Section = "A",
+            AcademicYear = "2026",
+        });
+        context.Users.Add(new UserEntity
         {
-            context.Schools.Add(new SchoolEntity
-            {
-                Id = schoolId,
-                Name = "Test School",
-                Code = "TEST",
-                Address = "",
-                ContactPhone = "",
-                ContactEmail = "",
-            });
-            context.Classes.Add(new ClassEntity
-            {
-                Id = classId,
-                SchoolId = schoolId,
-                Name = "6",
-                Section = "A",
-                AcademicYear = "2026",
-            });
-            context.Users.Add(new UserEntity
-            {
-                Id = teacherId,
-                SchoolId = schoolId,
-                Name = "Teacher",
-                Phone = "09000000001",
-                Role = "Teacher",
-            });
-            context.Homeworks.Add(new HomeworkEntity
-            {
-                Id = homeworkId,
-                SchoolId = schoolId,
-                ClassId = classId,
-                Subject = "Math",
-                Title = "HW 1",
-                Description = "",
-                DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(3)),
-                Status = "Published",
-                AssignedById = teacherId,
-            });
+            Id = teacherId,
+            SchoolId = schoolId,
+            Name = "Teacher",
+            Phone = "09000000001",
+            Role = "Teacher",
+        });
+        context.Homeworks.Add(new HomeworkEntity
+        {
+            Id = homeworkId,
+            SchoolId = schoolId,
+            ClassId = classId,
+            Subject = "Math",
+            Title = "HW 1",
+            Description = "",
+            DueDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(3)),
+            Status = "Published",
+            AssignedById = teacherId,
+        });
 
-            foreach (var status in new[]
+        var nowSeed = DateTimeOffset.UtcNow;
+        var i = 0;
+        foreach (var status in new[]
+        {
+            AttachmentStatus.Pending,
+            AttachmentStatus.Available,
+            AttachmentStatus.Infected,
+            AttachmentStatus.ScanFailed,
+        })
+        {
+            context.Attachments.Add(new AttachmentEntity
             {
-                AttachmentStatus.Pending,
-                AttachmentStatus.Available,
-                AttachmentStatus.Infected,
-                AttachmentStatus.ScanFailed,
-            })
-            {
-                context.Attachments.Add(new AttachmentEntity
-                {
-                    Id = Guid.NewGuid(),
-                    SchoolId = schoolId,
-                    EntityId = homeworkId,
-                    EntityType = "homework",
-                    StorageKey = $"test/{status}.pdf",
-                    FileName = $"{status}.pdf",
-                    ContentType = "application/pdf",
-                    SizeBytes = 100,
-                    UploadedById = teacherId,
-                    UploadedAt = DateTimeOffset.UtcNow,
-                    Status = status,
-                });
-            }
-
-            await context.SaveChangesAsync();
+                Id = Guid.NewGuid(),
+                SchoolId = schoolId,
+                EntityId = homeworkId,
+                EntityType = "homework",
+                StorageKey = $"test/{status}.pdf",
+                FileName = $"{status}.pdf",
+                ContentType = "application/pdf",
+                SizeBytes = 100,
+                UploadedById = teacherId,
+                UploadedAt = nowSeed.AddSeconds(i++),
+                Status = status,
+            });
         }
 
-        var storage = new Mock<IStorageService>(MockBehavior.Strict);
-        storage.Setup(s => s.GeneratePresignedDownloadUrlAsync(
-                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync("https://signed/");
-
-        await using var readContext = new AppDbContext(options, currentUser);
-        var handler = new GetAttachmentsForEntityQueryHandler(readContext, currentUser, storage.Object);
-
-        var result = await handler.Handle(
-            new GetAttachmentsForEntityQuery(homeworkId, "homework"),
-            CancellationToken.None);
-
-        result.Should().ContainSingle(
-            "only rows with Status=Available should be handed out for download");
-        result[0].FileName.Should().Be($"{AttachmentStatus.Available}.pdf");
-
-        // Presigned URL must have been requested exactly once — the Pending,
-        // Infected, and ScanFailed rows never reach the storage service.
-        storage.Verify(
-            s => s.GeneratePresignedDownloadUrlAsync(
-                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        await context.SaveChangesAsync();
+        return (options, schoolId, homeworkId, teacherId);
     }
 
     [Fact]

--- a/apps/web/components/shared/attachment-list.tsx
+++ b/apps/web/components/shared/attachment-list.tsx
@@ -4,8 +4,19 @@ import * as React from "react";
 import { ApiError, apiGet } from "@/lib/api-client";
 import { API_ENDPOINTS } from "@/lib/constants";
 import { Spinner } from "@/components/ui/spinner";
-import { Download, FileText, ImageIcon, Paperclip } from "lucide-react";
-import type { AttachmentEntityType, AttachmentItem } from "@/lib/types/attachment";
+import {
+  AlertTriangle,
+  Download,
+  FileText,
+  ImageIcon,
+  Loader2,
+  Paperclip,
+} from "lucide-react";
+import type {
+  AttachmentEntityType,
+  AttachmentItem,
+  AttachmentStatus,
+} from "@/lib/types/attachment";
 import {
   formatFileSize,
   isPdfAttachment,
@@ -17,6 +28,12 @@ interface AttachmentListProps {
   entityType: AttachmentEntityType;
 }
 
+// Re-poll every 5s while any row is Pending. Cap total polling to keep
+// the network footprint bounded — after the deadline the user has to
+// reload the page (the badge stays "Scanning…" so they see it).
+const POLL_INTERVAL_MS = 5_000;
+const POLL_DEADLINE_MS = 2 * 60 * 1_000;
+
 export function AttachmentList({
   entityId,
   entityType,
@@ -25,27 +42,55 @@ export function AttachmentList({
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState("");
 
-  const fetchAttachments = React.useCallback(async () => {
-    setIsLoading(true);
-    setError("");
+  const fetchAttachments = React.useCallback(
+    async (showLoader: boolean) => {
+      if (showLoader) {
+        setIsLoading(true);
+      }
+      setError("");
 
-    try {
-      const data = await apiGet<AttachmentItem[]>(
-        `${API_ENDPOINTS.attachments}?entityId=${entityId}&entityType=${entityType}`
-      );
-      setAttachments(data);
-    } catch (err) {
-      setError(
-        err instanceof ApiError ? err.message : "Failed to load attachments."
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  }, [entityId, entityType]);
+      try {
+        const data = await apiGet<AttachmentItem[]>(
+          `${API_ENDPOINTS.attachments}?entityId=${entityId}&entityType=${entityType}`
+        );
+        setAttachments(data);
+      } catch (err) {
+        setError(
+          err instanceof ApiError ? err.message : "Failed to load attachments."
+        );
+      } finally {
+        if (showLoader) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [entityId, entityType]
+  );
 
   React.useEffect(() => {
-    void fetchAttachments();
+    void fetchAttachments(true);
   }, [fetchAttachments]);
+
+  // Background poll while any attachment is still scanning. Stops once
+  // every row resolves or the polling deadline passes — whichever comes
+  // first. The interval is recreated whenever attachments change, which
+  // is intentional: it lets the loop tear itself down the moment all
+  // Pending rows clear.
+  React.useEffect(() => {
+    const hasPending = attachments.some((a) => a.status === "Pending");
+    if (!hasPending) return;
+
+    const startedAt = Date.now();
+    const handle = window.setInterval(() => {
+      if (Date.now() - startedAt > POLL_DEADLINE_MS) {
+        window.clearInterval(handle);
+        return;
+      }
+      void fetchAttachments(false);
+    }, POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(handle);
+  }, [attachments, fetchAttachments]);
 
   if (isLoading) {
     return (
@@ -94,37 +139,104 @@ export function AttachmentList({
         </p>
       </div>
       <div className="space-y-1.5">
-        {attachments.map((attachment) => {
-          const opensInNewTab = !isWordAttachment(attachment.contentType);
-
-          return (
-            <a
-              key={attachment.id}
-              href={attachment.downloadUrl}
-              target={opensInNewTab ? "_blank" : undefined}
-              rel={opensInNewTab ? "noopener noreferrer" : undefined}
-              className="flex items-center gap-3 rounded-[20px] border border-border/70 bg-card/72 p-3 shadow-[0_14px_30px_-28px_rgba(15,40,69,0.4)] transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:bg-card/92 dark:bg-card/86"
-              aria-label={`Download ${attachment.fileName}`}
-            >
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-secondary/70">
-                {getFileIcon(attachment.contentType)}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-foreground">
-                  {attachment.fileName}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {formatFileSize(attachment.sizeBytes)}
-                </p>
-              </div>
-              <Download
-                className="h-4 w-4 shrink-0 text-muted-foreground"
-                aria-hidden="true"
-              />
-            </a>
-          );
-        })}
+        {attachments.map((attachment) => (
+          <AttachmentRow
+            key={attachment.id}
+            attachment={attachment}
+            getFileIcon={getFileIcon}
+          />
+        ))}
       </div>
     </div>
+  );
+}
+
+interface AttachmentRowProps {
+  attachment: AttachmentItem;
+  getFileIcon: (contentType: string) => React.ReactNode;
+}
+
+function AttachmentRow({
+  attachment,
+  getFileIcon,
+}: AttachmentRowProps): React.ReactElement {
+  const isAvailable = attachment.status === "Available";
+  const opensInNewTab = !isWordAttachment(attachment.contentType);
+  const baseClass =
+    "flex items-center gap-3 rounded-[20px] border border-border/70 bg-card/72 p-3 shadow-[0_14px_30px_-28px_rgba(15,40,69,0.4)] dark:bg-card/86";
+
+  const body = (
+    <>
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-secondary/70">
+        {getFileIcon(attachment.contentType)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">
+          {attachment.fileName}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatFileSize(attachment.sizeBytes)}
+        </p>
+      </div>
+      <StatusBadge status={attachment.status} />
+      {isAvailable && attachment.downloadUrl ? (
+        <Download
+          className="h-4 w-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  );
+
+  if (isAvailable && attachment.downloadUrl) {
+    return (
+      <a
+        href={attachment.downloadUrl}
+        target={opensInNewTab ? "_blank" : undefined}
+        rel={opensInNewTab ? "noopener noreferrer" : undefined}
+        className={`${baseClass} transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:bg-card/92`}
+        aria-label={`Download ${attachment.fileName}`}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return (
+    <div className={baseClass} aria-label={attachment.fileName}>
+      {body}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: AttachmentStatus }): React.ReactElement | null {
+  if (status === "Available") return null;
+
+  if (status === "Pending") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Scanning…
+      </span>
+    );
+  }
+
+  if (status === "ScanFailed") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+        <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+        Scan failed
+      </span>
+    );
+  }
+
+  // Infected rows are filtered out server-side for every role today, so
+  // this branch is unreachable. Render a generic blocked badge as a
+  // belt-and-braces fallback in case the server ever changes.
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+      <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+      Blocked
+    </span>
   );
 }

--- a/apps/web/components/shared/attachment-uploader.tsx
+++ b/apps/web/components/shared/attachment-uploader.tsx
@@ -22,6 +22,7 @@ import {
   getAcceptedFiles,
   getAttachmentEmptyLabel,
   getAttachmentHelperText,
+  getAttachmentTypeRejectionMessage,
   isAllowedContentType,
   isPdfAttachment,
   isWordAttachment,
@@ -222,12 +223,7 @@ export function AttachmentUploader({
 
       for (const file of filesToUpload) {
         if (!isAllowedContentType(entityType, file.type)) {
-          addFileError(
-            file,
-            entityType === "homework"
-              ? "Only PDF and Word documents are allowed."
-              : "Only JPEG, PNG, WebP, and PDF files are allowed."
-          );
+          addFileError(file, getAttachmentTypeRejectionMessage(entityType));
           continue;
         }
 
@@ -266,12 +262,7 @@ export function AttachmentUploader({
           return;
         }
 
-        addFileError(
-          file,
-          entityType === "homework"
-            ? "Only PDF and Word documents are allowed."
-            : "Only JPEG, PNG, WebP, and PDF files are allowed."
-        );
+        addFileError(file, getAttachmentTypeRejectionMessage(entityType));
       });
     },
     [addFileError, entityType]

--- a/apps/web/lib/types/attachment.ts
+++ b/apps/web/lib/types/attachment.ts
@@ -1,3 +1,9 @@
+export type AttachmentStatus =
+  | "Pending"
+  | "Available"
+  | "Infected"
+  | "ScanFailed";
+
 export interface AttachmentItem {
   id: string;
   fileName: string;
@@ -5,9 +11,13 @@ export interface AttachmentItem {
   sizeBytes: number;
   downloadUrl: string;
   uploadedAt: string;
+  status: AttachmentStatus;
 }
 
-export type AttachmentEntityType = "homework" | "notice";
+export type AttachmentEntityType =
+  | "homework"
+  | "homework_submission"
+  | "notice";
 
 export interface RequestUploadUrlRequest {
   fileName: string;
@@ -48,6 +58,18 @@ export const HOMEWORK_ALLOWED_CONTENT_TYPES = [
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ] as const;
 
+// Mirrors AttachmentFeatureRules.HomeworkSubmissionAllowedContentTypes on
+// the API. Submissions accept the homework set plus common image formats
+// (photo of handwritten work).
+export const HOMEWORK_SUBMISSION_ALLOWED_CONTENT_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+] as const;
+
 export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 export const MAX_ATTACHMENTS_PER_ENTITY = 5;
 
@@ -63,6 +85,14 @@ export const ATTACHMENT_ACCEPT = {
     "application/msword": [".doc"],
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
   },
+  homework_submission: {
+    "image/jpeg": [".jpg", ".jpeg"],
+    "image/png": [".png"],
+    "image/webp": [".webp"],
+    "application/pdf": [".pdf"],
+    "application/msword": [".doc"],
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+  },
 } as const;
 
 export type NoticeAllowedContentType =
@@ -71,16 +101,25 @@ export type NoticeAllowedContentType =
 export type HomeworkAllowedContentType =
   (typeof HOMEWORK_ALLOWED_CONTENT_TYPES)[number];
 
+export type HomeworkSubmissionAllowedContentType =
+  (typeof HOMEWORK_SUBMISSION_ALLOWED_CONTENT_TYPES)[number];
+
 export type AllowedContentType =
   | NoticeAllowedContentType
-  | HomeworkAllowedContentType;
+  | HomeworkAllowedContentType
+  | HomeworkSubmissionAllowedContentType;
 
 export function getAllowedContentTypes(
   entityType: AttachmentEntityType
 ): readonly string[] {
-  return entityType === "homework"
-    ? HOMEWORK_ALLOWED_CONTENT_TYPES
-    : NOTICE_ALLOWED_CONTENT_TYPES;
+  switch (entityType) {
+    case "homework":
+      return HOMEWORK_ALLOWED_CONTENT_TYPES;
+    case "homework_submission":
+      return HOMEWORK_SUBMISSION_ALLOWED_CONTENT_TYPES;
+    case "notice":
+      return NOTICE_ALLOWED_CONTENT_TYPES;
+  }
 }
 
 export function getAcceptedFiles(
@@ -117,15 +156,38 @@ export function isWordAttachment(contentType: string): boolean {
 export function getAttachmentHelperText(
   entityType: AttachmentEntityType
 ): string {
-  return entityType === "homework"
-    ? "PDF, DOC, or DOCX — max 10MB each"
-    : "JPEG, PNG, WebP, or PDF — max 10MB each";
+  switch (entityType) {
+    case "homework":
+      return "PDF, DOC, or DOCX — max 10MB each";
+    case "homework_submission":
+      return "PDF, DOC, DOCX, or image — max 10MB each";
+    case "notice":
+      return "JPEG, PNG, WebP, or PDF — max 10MB each";
+  }
 }
 
 export function getAttachmentEmptyLabel(
   entityType: AttachmentEntityType
 ): string {
-  return entityType === "homework"
-    ? "Drag and drop homework files here, or browse"
-    : "Drag and drop notice files here, or browse";
+  switch (entityType) {
+    case "homework":
+      return "Drag and drop homework files here, or browse";
+    case "homework_submission":
+      return "Drag and drop your submission files here, or browse";
+    case "notice":
+      return "Drag and drop notice files here, or browse";
+  }
+}
+
+export function getAttachmentTypeRejectionMessage(
+  entityType: AttachmentEntityType
+): string {
+  switch (entityType) {
+    case "homework":
+      return "Only PDF and Word documents are allowed.";
+    case "homework_submission":
+      return "Only PDF, Word documents, and images are allowed.";
+    case "notice":
+      return "Only JPEG, PNG, WebP, and PDF files are allowed.";
+  }
 }


### PR DESCRIPTION
Three coordinated changes that finish the homework_submission feature and surface scan progress to uploaders.

4.1 homework_submission in the FE type union. Widens
    AttachmentEntityType to "homework" | "homework_submission" |
    "notice"; mirrors AttachmentFeatureRules.HomeworkSubmissionAllowed
    sets in HOMEWORK_SUBMISSION_ALLOWED_CONTENT_TYPES; adds the third
    branch to ATTACHMENT_ACCEPT (PDF + DOC + DOCX + JPG + PNG + WEBP).
    Replaces every entityType === "homework" binary in the uploader
    with a switch via getAttachmentHelperText /
    getAttachmentEmptyLabel / getAttachmentTypeRejectionMessage so
    adding a fourth entity type later is a one-place change.

4.2 Scan-progress visible to uploaders. AttachmentDto gains a Status
    field and DownloadUrl becomes nullable. The handler exposes
    Available + Pending + ScanFailed to admins and teachers (Infected
    stays hidden — admins are notified out-of-band in Phase 6);
    parents and other roles still see only Available. Presigned URL
    is only minted for Available rows regardless of role, so the read
    path can never hand out an unscanned object.

    AttachmentList renders a per-status badge (Loader2 spinner +
    "Scanning…" for Pending, AlertTriangle + "Scan failed" for
    ScanFailed) and polls every 5s while any row is Pending, capped
    at 2 minutes. The download link is suppressed for any row whose
    downloadUrl is null.

4.3 V2 response-shape doc fix. The flow diagram and a new "V2 upload
    response shape" section in attachment-virus-scanning.md now match
    the actual response: { uploadUrl, attachmentId } (no storageKey).
    A short comment on RequestUploadUrlV2Response codifies the
    intentional omission.

Tests:
- AttachmentScanFlowTests — replaced the single-status filter test with two role-targeted tests: teacher sees Pending + Available + ScanFailed (Infected hidden, presigned URL only on Available), parent sees only Available.

Suite: 135 BE passed, 2 pre-existing AdminOnboarding failures unchanged. FE tsc clean; lint warnings are pre-existing push code.