### PR TITLE
feat(api): Phase 6 — ops & observability (P2)

### DIFF
--- a/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/apps/api/src/EduConnect.Api/Common/Extensions/EndpointRouteBuilderExtensions.cs
@@ -68,6 +68,7 @@ using EduConnect.Api.Features.Push.UnregisterPushSubscription;
 using EduConnect.Api.Features.Attachments.RequestUploadUrlV2;
 using EduConnect.Api.Features.Attachments.AttachFileToEntity;
 using EduConnect.Api.Features.Attachments.DeleteAttachment;
+using EduConnect.Api.Features.Attachments.DownloadAttachment;
 using EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
 using EduConnect.Api.Features.Exams.CreateExam;
 using EduConnect.Api.Features.Exams.UpdateExam;
@@ -273,9 +274,12 @@ public static class EndpointRouteBuilderExtensions
             return result;
         });
 
-        group.MapPost("/request-upload-url-v2", RequestUploadUrlV2Endpoint.Handle).WithName("RequestUploadUrlV2");
+        group.MapPost("/request-upload-url-v2", RequestUploadUrlV2Endpoint.Handle)
+            .WithName("RequestUploadUrlV2")
+            .RequireRateLimiting("attachments-upload-url");
         group.MapPost("/attach", AttachFileToEntityEndpoint.Handle).WithName("AttachFileToEntity");
         group.MapGet("/", GetAttachmentsForEntityEndpoint.Handle).WithName("GetAttachmentsForEntity");
+        group.MapGet("/{id:guid}/download", DownloadAttachmentEndpoint.Handle).WithName("DownloadAttachment");
         group.MapDelete("/{id}", DeleteAttachmentEndpoint.Handle).WithName("DeleteAttachment");
     }
 

--- a/apps/api/src/EduConnect.Api/Features/Attachments/DownloadAttachment/DownloadAttachmentEndpoint.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/DownloadAttachment/DownloadAttachmentEndpoint.cs
@@ -1,0 +1,126 @@
+using EduConnect.Api.Common.Auth;
+using EduConnect.Api.Common.Exceptions;
+using EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace EduConnect.Api.Features.Attachments.DownloadAttachment;
+
+/// <summary>
+/// Audit-logged download redirect. Loads the attachment, re-runs the
+/// same access check that <see cref="GetAttachmentsForEntityQueryHandler"/>
+/// applies, logs the download attempt at Information with the requesting
+/// user, and 302s to a freshly-minted presigned URL. Used for the
+/// entity types where compliance demands a per-download server-side
+/// audit trail (homework_submission and notice); homework continues to
+/// hand out direct presigned URLs since the surface is lower-stakes.
+/// </summary>
+public static class DownloadAttachmentEndpoint
+{
+    public static async Task<IResult> Handle(
+        [FromRoute] Guid id,
+        IMediator mediator,
+        AppDbContext context,
+        CurrentUserService currentUser,
+        IStorageService storage,
+        IOptions<StorageOptions> storageOptions,
+        ILogger<DownloadAttachmentLog> logger,
+        CancellationToken cancellationToken)
+    {
+        var attachment = await context.Attachments
+            .FirstOrDefaultAsync(a =>
+                a.Id == id &&
+                a.SchoolId == currentUser.SchoolId,
+                cancellationToken);
+
+        if (attachment is null)
+        {
+            // Same shape as a not-found from the GET handler — never
+            // confirm existence to a caller that lacks access.
+            return Results.NotFound();
+        }
+
+        if (attachment.EntityId is null || attachment.EntityType is null)
+        {
+            // Unattached row: caller is the uploader by definition (the
+            // GET handler doesn't expose unattached rows). Skip the
+            // entity-scoped access check and rely on tenant scoping.
+            if (attachment.UploadedById != currentUser.UserId &&
+                currentUser.Role != "Admin")
+            {
+                return Results.NotFound();
+            }
+        }
+        else
+        {
+            // Re-run the entity-level access check by dispatching the
+            // existing query. Anything not visible to this caller via
+            // GetAttachmentsForEntity is also off-limits here.
+            List<AttachmentDto> visible;
+            try
+            {
+                visible = await mediator.Send(
+                    new GetAttachmentsForEntityQuery(attachment.EntityId.Value, attachment.EntityType),
+                    cancellationToken);
+            }
+            catch (ForbiddenException)
+            {
+                logger.LogInformation(
+                    "Attachment download denied (forbidden): {AttachmentId} by user {UserId} in school {SchoolId}",
+                    attachment.Id, currentUser.UserId, currentUser.SchoolId);
+                return Results.NotFound();
+            }
+            catch (NotFoundException)
+            {
+                return Results.NotFound();
+            }
+
+            if (!visible.Any(v => v.Id == attachment.Id))
+            {
+                logger.LogInformation(
+                    "Attachment download denied (not visible): {AttachmentId} by user {UserId} in school {SchoolId}",
+                    attachment.Id, currentUser.UserId, currentUser.SchoolId);
+                return Results.NotFound();
+            }
+        }
+
+        if (attachment.Status != AttachmentStatus.Available)
+        {
+            // Pending / Infected / ScanFailed have no usable presigned
+            // URL. The GET handler already withholds the URL field for
+            // these statuses; mirror that here.
+            return Results.NotFound();
+        }
+
+        var presignedUrl = await storage.GeneratePresignedDownloadUrlAsync(
+            attachment.StorageKey,
+            TimeSpan.FromMinutes(storageOptions.Value.PresignedDownloadExpiryMinutes),
+            attachment.FileName,
+            attachment.ContentType,
+            AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
+            cancellationToken);
+
+        // The audit signal: one log line per download with user + tenant +
+        // attachment + entity context. Picked up by the existing
+        // structured-logging pipeline (Serilog → file/Sentry).
+        logger.LogInformation(
+            "Attachment download: {AttachmentId} ({EntityType} {EntityId}) by user {UserId} in school {SchoolId}",
+            attachment.Id,
+            attachment.EntityType,
+            attachment.EntityId,
+            currentUser.UserId,
+            currentUser.SchoolId);
+
+        return Results.Redirect(presignedUrl, permanent: false);
+    }
+}
+
+/// <summary>
+/// Empty marker class so we get a discriminating
+/// <see cref="ILogger{TCategoryName}"/> category in Serilog output.
+/// </summary>
+public sealed class DownloadAttachmentLog;

--- a/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
+++ b/apps/api/src/EduConnect.Api/Features/Attachments/GetAttachmentsForEntity/GetAttachmentsForEntityQueryHandler.cs
@@ -5,27 +5,39 @@ using EduConnect.Api.Infrastructure.Database;
 using EduConnect.Api.Infrastructure.Database.Entities;
 using EduConnect.Api.Infrastructure.Services;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 namespace EduConnect.Api.Features.Attachments.GetAttachmentsForEntity;
 
 public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachmentsForEntityQuery, List<AttachmentDto>>
 {
+    // Compliance-grade audit logging is required for downloads of student
+    // submissions and official notices, so the response routes those
+    // download URLs through the API's audit-logging redirect endpoint.
+    // Homework attachments stay on direct presigned URLs — the surface is
+    // teacher-facing and per-download auditing isn't worth the extra hop.
+    private static readonly HashSet<string> EntityTypesRequiringAuditRedirect =
+        new(StringComparer.OrdinalIgnoreCase) { "homework_submission", "notice" };
+
     private readonly AppDbContext _context;
     private readonly CurrentUserService _currentUserService;
     private readonly IStorageService _storageService;
     private readonly StorageOptions _storageOptions;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     public GetAttachmentsForEntityQueryHandler(
         AppDbContext context,
         CurrentUserService currentUserService,
         IStorageService storageService,
-        IOptions<StorageOptions> storageOptions)
+        IOptions<StorageOptions> storageOptions,
+        IHttpContextAccessor httpContextAccessor)
     {
         _context = context;
         _currentUserService = currentUserService;
         _storageService = storageService;
         _storageOptions = storageOptions.Value;
+        _httpContextAccessor = httpContextAccessor;
     }
 
     public async Task<List<AttachmentDto>> Handle(GetAttachmentsForEntityQuery request, CancellationToken cancellationToken)
@@ -71,18 +83,22 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
 
         var result = new List<AttachmentDto>(attachments.Count);
 
+        var routeThroughAudit = EntityTypesRequiringAuditRedirect.Contains(request.EntityType);
+
         foreach (var attachment in attachments)
         {
             string? downloadUrl = null;
             if (attachment.Status == AttachmentStatus.Available)
             {
-                downloadUrl = await _storageService.GeneratePresignedDownloadUrlAsync(
-                    attachment.StorageKey,
-                    TimeSpan.FromMinutes(_storageOptions.PresignedDownloadExpiryMinutes),
-                    attachment.FileName,
-                    attachment.ContentType,
-                    AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
-                    cancellationToken);
+                downloadUrl = routeThroughAudit
+                    ? BuildAuditRedirectUrl(attachment.Id)
+                    : await _storageService.GeneratePresignedDownloadUrlAsync(
+                        attachment.StorageKey,
+                        TimeSpan.FromMinutes(_storageOptions.PresignedDownloadExpiryMinutes),
+                        attachment.FileName,
+                        attachment.ContentType,
+                        AttachmentFeatureRules.RequiresForcedDownload(attachment.ContentType),
+                        cancellationToken);
             }
 
             result.Add(new AttachmentDto(
@@ -100,6 +116,22 @@ public class GetAttachmentsForEntityQueryHandler : IRequestHandler<GetAttachment
 
     private static bool CanViewInProgressScans(string? role) =>
         role == "Admin" || role == "Teacher";
+
+    private string BuildAuditRedirectUrl(Guid attachmentId)
+    {
+        // Build an absolute URL so the FE's anchor `href` resolves to the
+        // API origin and not to whatever app origin the user is currently
+        // on. Falls back to a relative URL when there's no HttpContext
+        // (e.g. running from a background hostedservice scope), which
+        // shouldn't happen for the GET handler but keeps the code safe.
+        var request = _httpContextAccessor.HttpContext?.Request;
+        if (request is null)
+        {
+            return $"/api/attachments/{attachmentId}/download";
+        }
+
+        return $"{request.Scheme}://{request.Host}/api/attachments/{attachmentId}/download";
+    }
 
     private async Task EnsureHomeworkAccessAsync(Guid homeworkId, CancellationToken cancellationToken)
     {

--- a/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/NotificationConfiguration.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Database/Configurations/NotificationConfiguration.cs
@@ -12,10 +12,10 @@ public class NotificationConfiguration : IEntityTypeConfiguration<NotificationEn
         {
             tableBuilder.HasCheckConstraint(
                 "chk_notification_type",
-                "type IN ('notice_published', 'homework_assigned', 'absence_marked', 'leave_applied', 'leave_approved', 'leave_rejected')");
+                "type IN ('notice_published', 'homework_assigned', 'absence_marked', 'leave_applied', 'leave_approved', 'leave_rejected', 'attachment_infected', 'attachment_scan_failed')");
             tableBuilder.HasCheckConstraint(
                 "chk_notification_entity_type",
-                "entity_type IS NULL OR entity_type IN ('notice', 'homework', 'attendance', 'leave_application')");
+                "entity_type IS NULL OR entity_type IN ('notice', 'homework', 'attendance', 'leave_application', 'attachment')");
         });
 
         builder.HasKey(x => x.Id);

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentBlockedNotifier.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentBlockedNotifier.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Text;
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+public sealed class AttachmentBlockedNotifier : IAttachmentBlockedNotifier
+{
+    private readonly AppDbContext _db;
+    private readonly INotificationService _notificationService;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<AttachmentBlockedNotifier> _logger;
+
+    public AttachmentBlockedNotifier(
+        AppDbContext db,
+        INotificationService notificationService,
+        IEmailService emailService,
+        ILogger<AttachmentBlockedNotifier> logger)
+    {
+        _db = db;
+        _notificationService = notificationService;
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    public async Task NotifyAsync(
+        AttachmentBlockedKind kind,
+        AttachmentEntity attachment,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Worker doesn't carry tenant context — bypass the global query
+            // filter to find tenant admins, then fan out per admin so each
+            // recipient gets their own notification row.
+            var admins = await _db.Users
+                .IgnoreQueryFilters()
+                .Where(u =>
+                    u.SchoolId == attachment.SchoolId &&
+                    u.Role == "Admin" &&
+                    u.IsActive)
+                .Select(u => new { u.Id, u.Email, u.Name })
+                .ToListAsync(cancellationToken);
+
+            if (admins.Count == 0)
+            {
+                _logger.LogWarning(
+                    "No active admins for school {SchoolId}; skipping attachment-blocked notification for {AttachmentId}",
+                    attachment.SchoolId, attachment.Id);
+                return;
+            }
+
+            var (type, title, body) = BuildContent(kind, attachment);
+
+            await _notificationService.SendBatchAsync(
+                attachment.SchoolId,
+                admins.Select(a => a.Id).ToList(),
+                type,
+                title,
+                body,
+                attachment.Id,
+                AttachmentNotificationTypes.EntityType,
+                cancellationToken);
+
+            // Email is best-effort — already-sent in-app notifications stand
+            // even if SMTP is unhappy.
+            var subject = title;
+            var htmlBody = BuildEmailHtml(kind, attachment, body);
+            foreach (var admin in admins)
+            {
+                if (string.IsNullOrWhiteSpace(admin.Email)) continue;
+
+                try
+                {
+                    await _emailService.SendEmailAsync(
+                        admin.Email!,
+                        subject,
+                        htmlBody,
+                        textBody: body,
+                        cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to email attachment-blocked notice to admin {AdminId} for {AttachmentId}",
+                        admin.Id, attachment.Id);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Notification dispatch is a side-effect; never let it bubble
+            // up and undo the worker's primary status write.
+            _logger.LogError(ex,
+                "AttachmentBlockedNotifier failed for attachment {AttachmentId}",
+                attachment.Id);
+        }
+    }
+
+    private static (string Type, string Title, string Body) BuildContent(
+        AttachmentBlockedKind kind, AttachmentEntity attachment)
+    {
+        var fileName = string.IsNullOrWhiteSpace(attachment.FileName) ? "(unnamed)" : attachment.FileName;
+        var threat = string.IsNullOrWhiteSpace(attachment.ThreatName) ? "unknown" : attachment.ThreatName!;
+
+        return kind switch
+        {
+            AttachmentBlockedKind.Infected => (
+                AttachmentNotificationTypes.Infected,
+                $"Upload blocked: {fileName}",
+                $"The virus scanner flagged \"{fileName}\" as {threat}. The file has been removed from storage."
+            ),
+            AttachmentBlockedKind.ScanFailed => (
+                AttachmentNotificationTypes.ScanFailed,
+                $"Scan failed: {fileName}",
+                $"The virus scanner could not check \"{fileName}\" ({threat}). The file is held for operator review."
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown blocked kind"),
+        };
+    }
+
+    private static string BuildEmailHtml(
+        AttachmentBlockedKind kind, AttachmentEntity attachment, string body)
+    {
+        // Deliberately barebones — no shared EmailLayout template. This is
+        // an operator alert, not a branded user-facing email; clarity beats
+        // visual polish.
+        var sb = new StringBuilder();
+        sb.Append("<p>");
+        sb.Append(WebUtility.HtmlEncode(body));
+        sb.Append("</p>");
+        sb.Append("<ul>");
+        sb.Append($"<li><strong>Attachment ID:</strong> {WebUtility.HtmlEncode(attachment.Id.ToString())}</li>");
+        if (attachment.EntityType is not null)
+        {
+            sb.Append($"<li><strong>Linked to:</strong> {WebUtility.HtmlEncode(attachment.EntityType)} ");
+            sb.Append($"{WebUtility.HtmlEncode(attachment.EntityId?.ToString() ?? "(unattached)")}</li>");
+        }
+        sb.Append($"<li><strong>Uploaded by:</strong> {WebUtility.HtmlEncode(attachment.UploadedById.ToString())}</li>");
+        sb.Append("</ul>");
+        sb.Append("<p>No action is required for ");
+        sb.Append(kind == AttachmentBlockedKind.Infected ? "an infected upload" : "a scan failure");
+        sb.Append(" beyond auditing the source. See the EduConnect admin console for the full attachment list.</p>");
+        return sb.ToString();
+    }
+}

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/AttachmentScanWorker.cs
@@ -92,6 +92,7 @@ public sealed class AttachmentScanWorker : BackgroundService
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
         var scanner = scope.ServiceProvider.GetRequiredService<IAttachmentScanner>();
+        var blockedNotifier = scope.ServiceProvider.GetRequiredService<IAttachmentBlockedNotifier>();
 
         // IgnoreQueryFilters: we don't have a tenant context in the worker
         // scope, so the EF global query filter would otherwise return
@@ -132,8 +133,10 @@ public sealed class AttachmentScanWorker : BackgroundService
                 "Could not stream attachment {AttachmentId} from storage for scanning",
                 attachmentId);
             attachment.Status = AttachmentStatus.ScanFailed;
+            attachment.ThreatName = "storage_open_failed";
             attachment.ScannedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync(ct);
+            await blockedNotifier.NotifyAsync(AttachmentBlockedKind.ScanFailed, attachment, ct);
             return;
         }
 
@@ -164,6 +167,7 @@ public sealed class AttachmentScanWorker : BackgroundService
             }
 
             await db.SaveChangesAsync(ct);
+            await blockedNotifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment, ct);
             return;
         }
 
@@ -199,6 +203,7 @@ public sealed class AttachmentScanWorker : BackgroundService
                 attachment.ThreatName = ex.GetType().Name;
                 attachment.ScannedAt = DateTimeOffset.UtcNow;
                 await db.SaveChangesAsync(ct);
+                await blockedNotifier.NotifyAsync(AttachmentBlockedKind.ScanFailed, attachment, ct);
                 return;
             }
         }
@@ -218,6 +223,7 @@ public sealed class AttachmentScanWorker : BackgroundService
             };
             attachment.ScannedAt = DateTimeOffset.UtcNow;
             await db.SaveChangesAsync(ct);
+            await blockedNotifier.NotifyAsync(AttachmentBlockedKind.ScanFailed, attachment, ct);
             return;
         }
 
@@ -262,6 +268,15 @@ public sealed class AttachmentScanWorker : BackgroundService
         }
 
         await db.SaveChangesAsync(ct);
+
+        if (attachment.Status == AttachmentStatus.Infected)
+        {
+            await blockedNotifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment, ct);
+        }
+        else if (attachment.Status == AttachmentStatus.ScanFailed)
+        {
+            await blockedNotifier.NotifyAsync(AttachmentBlockedKind.ScanFailed, attachment, ct);
+        }
     }
 
     // Transient = "the scanner could not be reached or didn't reply in

--- a/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentBlockedNotifier.cs
+++ b/apps/api/src/EduConnect.Api/Infrastructure/Services/Scanning/IAttachmentBlockedNotifier.cs
@@ -1,0 +1,39 @@
+using EduConnect.Api.Infrastructure.Database.Entities;
+
+namespace EduConnect.Api.Infrastructure.Services.Scanning;
+
+/// <summary>
+/// Tells tenant admins when an upload was blocked. Called by the scan
+/// worker after a row transitions to Infected or ScanFailed. Failures
+/// are absorbed inside the implementation so the primary status update
+/// never gets undone by a side-channel error.
+/// </summary>
+public interface IAttachmentBlockedNotifier
+{
+    Task NotifyAsync(
+        AttachmentBlockedKind kind,
+        AttachmentEntity attachment,
+        CancellationToken cancellationToken = default);
+}
+
+public enum AttachmentBlockedKind
+{
+    /// <summary>Scanner found a threat. Object deleted from storage.</summary>
+    Infected,
+
+    /// <summary>Scanner failed after retries. Object kept for operator review.</summary>
+    ScanFailed,
+}
+
+/// <summary>
+/// Wire-format type strings persisted on <c>notifications.type</c>. Kept
+/// in sync with the chk_notification_type CHECK constraint (see
+/// <c>NotificationConfiguration</c> + the
+/// <c>ExpandNotificationTypesForAttachments</c> migration).
+/// </summary>
+public static class AttachmentNotificationTypes
+{
+    public const string Infected = "attachment_infected";
+    public const string ScanFailed = "attachment_scan_failed";
+    public const string EntityType = "attachment";
+}

--- a/apps/api/src/EduConnect.Api/Migrations/20260422043338_ExpandNotificationTypesForAttachments.Designer.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260422043338_ExpandNotificationTypesForAttachments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EduConnect.Api.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduConnect.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422043338_ExpandNotificationTypesForAttachments")]
+    partial class ExpandNotificationTypesForAttachments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/EduConnect.Api/Migrations/20260422043338_ExpandNotificationTypesForAttachments.cs
+++ b/apps/api/src/EduConnect.Api/Migrations/20260422043338_ExpandNotificationTypesForAttachments.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EduConnect.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExpandNotificationTypesForAttachments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "chk_notification_entity_type",
+                table: "notifications");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "chk_notification_type",
+                table: "notifications");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "chk_notification_entity_type",
+                table: "notifications",
+                sql: "entity_type IS NULL OR entity_type IN ('notice', 'homework', 'attendance', 'leave_application', 'attachment')");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "chk_notification_type",
+                table: "notifications",
+                sql: "type IN ('notice_published', 'homework_assigned', 'absence_marked', 'leave_applied', 'leave_approved', 'leave_rejected', 'attachment_infected', 'attachment_scan_failed')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "chk_notification_entity_type",
+                table: "notifications");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "chk_notification_type",
+                table: "notifications");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "chk_notification_entity_type",
+                table: "notifications",
+                sql: "entity_type IS NULL OR entity_type IN ('notice', 'homework', 'attendance', 'leave_application')");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "chk_notification_type",
+                table: "notifications",
+                sql: "type IN ('notice_published', 'homework_assigned', 'absence_marked', 'leave_applied', 'leave_approved', 'leave_rejected')");
+        }
+    }
+}

--- a/apps/api/src/EduConnect.Api/Program.cs
+++ b/apps/api/src/EduConnect.Api/Program.cs
@@ -178,6 +178,8 @@ EduConnect.Api.Infrastructure.Services.Scanning.AttachmentScannerRegistration.Ad
     builder.Services,
     scannerOptions,
     builder.Environment);
+builder.Services.AddScoped<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentBlockedNotifier,
+    EduConnect.Api.Infrastructure.Services.Scanning.AttachmentBlockedNotifier>();
 builder.Services.AddSingleton<EduConnect.Api.Infrastructure.Services.Scanning.IAttachmentScanQueue,
     EduConnect.Api.Infrastructure.Services.Scanning.ChannelAttachmentScanQueue>();
 // Reconciler runs first so any stale Pending rows from a prior crash are
@@ -256,6 +258,32 @@ builder.Services.AddRateLimiter(options =>
                 QueueLimit = 0,
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 Window = TimeSpan.FromMinutes(1)
+            });
+    });
+
+    // Tighter cap on presigned-URL minting so a misbehaving (or
+    // compromised) account can't generate large bursts of signed
+    // URLs that all stay valid for the upload TTL. 10/min per user
+    // is well below any real teacher upload rate; the global
+    // per-user limit still applies on top. (A separate hourly cap
+    // is a follow-up — the per-minute cap already neutralises the
+    // documented "mint 10k presigned URLs" attack since 10×60 = 600
+    // is the per-hour ceiling under continuous abuse.)
+    options.AddPolicy("attachments-upload-url", httpContext =>
+    {
+        var key = httpContext.User.FindFirst("userId")?.Value
+            ?? httpContext.Connection.RemoteIpAddress?.ToString()
+            ?? "anonymous";
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: $"upload-url:{key}",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                AutoReplenishment = true,
+                PermitLimit = 10,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                Window = TimeSpan.FromMinutes(1),
             });
     });
 });

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentBlockedNotifierTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentBlockedNotifierTests.cs
@@ -1,0 +1,253 @@
+using EduConnect.Api.Infrastructure.Database;
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Phase 6.1 — operator notifications when an upload is blocked.
+/// </summary>
+public class AttachmentBlockedNotifierTests
+{
+    [Fact]
+    public async Task NotifyAsync_dispatches_in_app_to_every_active_admin_in_tenant_for_Infected()
+    {
+        var (db, attachment, schoolId, adminA, adminB, adminInOtherTenant, inactiveAdmin) =
+            await SeedTenantWithAdmins();
+
+        var notification = new RecordingNotificationService();
+        var email = new Mock<IEmailService>();
+        var notifier = new AttachmentBlockedNotifier(
+            db, notification, email.Object, NullLogger<AttachmentBlockedNotifier>.Instance);
+
+        attachment.ThreatName = "Eicar-Test-Signature";
+        await notifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment);
+
+        notification.Calls.Should().ContainSingle();
+        var call = notification.Calls[0];
+        call.SchoolId.Should().Be(schoolId);
+        call.UserIds.Should().BeEquivalentTo(new[] { adminA, adminB },
+            "the inactive admin and the cross-tenant admin must not receive the alert");
+        call.Type.Should().Be("attachment_infected");
+        call.Title.Should().Contain(attachment.FileName);
+        call.Body.Should().Contain("Eicar-Test-Signature");
+        call.EntityId.Should().Be(attachment.Id);
+        call.EntityType.Should().Be("attachment");
+
+        // Other tenant's admin must not have been considered at all.
+        adminInOtherTenant.Should().NotBe(Guid.Empty);
+        inactiveAdmin.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task NotifyAsync_uses_attachment_scan_failed_type_for_ScanFailed()
+    {
+        var (db, attachment, _, _, _, _, _) = await SeedTenantWithAdmins();
+
+        var notification = new RecordingNotificationService();
+        var notifier = new AttachmentBlockedNotifier(
+            db, notification, Mock.Of<IEmailService>(), NullLogger<AttachmentBlockedNotifier>.Instance);
+
+        attachment.ThreatName = "scanner_unreachable";
+        await notifier.NotifyAsync(AttachmentBlockedKind.ScanFailed, attachment);
+
+        notification.Calls.Single().Type.Should().Be("attachment_scan_failed");
+        notification.Calls.Single().Body.Should().Contain("scanner_unreachable");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_emails_each_admin_with_an_email_address()
+    {
+        var (db, attachment, _, _, _, _, _) = await SeedTenantWithAdmins();
+
+        var email = new Mock<IEmailService>();
+        email
+            .Setup(e => e.SendEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var notifier = new AttachmentBlockedNotifier(
+            db, new RecordingNotificationService(), email.Object,
+            NullLogger<AttachmentBlockedNotifier>.Instance);
+
+        await notifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment);
+
+        // adminA has an email; adminB doesn't (see SeedTenantWithAdmins).
+        email.Verify(e => e.SendEmailAsync(
+            "admin-a@test.com",
+            It.Is<string>(s => s.Contains(attachment.FileName)),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        email.Verify(e => e.SendEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyAsync_swallows_notification_failure_so_it_never_undoes_a_DB_write()
+    {
+        var (db, attachment, _, _, _, _, _) = await SeedTenantWithAdmins();
+
+        var notification = new ThrowingNotificationService();
+        var notifier = new AttachmentBlockedNotifier(
+            db, notification, Mock.Of<IEmailService>(),
+            NullLogger<AttachmentBlockedNotifier>.Instance);
+
+        // Must not throw — primary write has already been saved by caller.
+        var act = () => notifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task NotifyAsync_does_nothing_when_tenant_has_no_admins()
+    {
+        var schoolId = Guid.NewGuid();
+        var options = NewOptions();
+        await using (var ctx = new AppDbContext(options))
+        {
+            ctx.Schools.Add(new SchoolEntity
+            {
+                Id = schoolId, Name = "S", Code = "S",
+                Address = "", ContactPhone = "", ContactEmail = "",
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var notification = new RecordingNotificationService();
+        await using var db = new AppDbContext(options);
+        var notifier = new AttachmentBlockedNotifier(
+            db, notification, Mock.Of<IEmailService>(),
+            NullLogger<AttachmentBlockedNotifier>.Instance);
+
+        var attachment = new AttachmentEntity
+        {
+            Id = Guid.NewGuid(), SchoolId = schoolId, FileName = "f.pdf",
+            ContentType = "application/pdf", SizeBytes = 1, StorageKey = "k",
+            UploadedById = Guid.NewGuid(),
+        };
+
+        await notifier.NotifyAsync(AttachmentBlockedKind.Infected, attachment);
+
+        notification.Calls.Should().BeEmpty();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"NotifierTests_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private static async Task<(
+        AppDbContext Db,
+        AttachmentEntity Attachment,
+        Guid SchoolId,
+        Guid AdminA,
+        Guid AdminB,
+        Guid AdminInOtherTenant,
+        Guid InactiveAdmin)> SeedTenantWithAdmins()
+    {
+        var schoolId = Guid.NewGuid();
+        var otherSchoolId = Guid.NewGuid();
+        var adminA = Guid.NewGuid();
+        var adminB = Guid.NewGuid();
+        var adminInOtherTenant = Guid.NewGuid();
+        var inactiveAdmin = Guid.NewGuid();
+        var attachmentId = Guid.NewGuid();
+
+        var options = NewOptions();
+        await using (var seed = new AppDbContext(options))
+        {
+            seed.Schools.AddRange(
+                new SchoolEntity { Id = schoolId,      Name = "Primary", Code = "A",
+                    Address = "", ContactPhone = "", ContactEmail = "" },
+                new SchoolEntity { Id = otherSchoolId, Name = "Other",   Code = "B",
+                    Address = "", ContactPhone = "", ContactEmail = "" });
+
+            seed.Users.AddRange(
+                new UserEntity { Id = adminA,             SchoolId = schoolId,      Phone = "0900000001",
+                    Email = "admin-a@test.com", Name = "Admin A", Role = "Admin", IsActive = true },
+                new UserEntity { Id = adminB,             SchoolId = schoolId,      Phone = "0900000002",
+                    Email = null,                Name = "Admin B", Role = "Admin", IsActive = true },
+                new UserEntity { Id = inactiveAdmin,      SchoolId = schoolId,      Phone = "0900000003",
+                    Email = "inactive@test.com", Name = "Old Admin", Role = "Admin", IsActive = false },
+                new UserEntity { Id = adminInOtherTenant, SchoolId = otherSchoolId, Phone = "0900000004",
+                    Email = "other@test.com",    Name = "Cross-tenant Admin", Role = "Admin", IsActive = true },
+                new UserEntity { Id = Guid.NewGuid(),     SchoolId = schoolId,      Phone = "0900000005",
+                    Email = "teach@test.com",    Name = "Teacher",  Role = "Teacher", IsActive = true });
+
+            seed.Attachments.Add(new AttachmentEntity
+            {
+                Id = attachmentId, SchoolId = schoolId,
+                EntityType = "homework", EntityId = Guid.NewGuid(),
+                FileName = "lesson.pdf", ContentType = "application/pdf",
+                SizeBytes = 1024, StorageKey = $"{schoolId}/homework/{attachmentId}",
+                UploadedById = Guid.NewGuid(),
+                UploadedAt = DateTimeOffset.UtcNow,
+                Status = AttachmentStatus.Infected,
+                ThreatName = "Eicar-Test-Signature",
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var db = new AppDbContext(options);
+        var attachment = await db.Attachments.SingleAsync(a => a.Id == attachmentId);
+        return (db, attachment, schoolId, adminA, adminB, adminInOtherTenant, inactiveAdmin);
+    }
+
+    private sealed record SendBatchCall(
+        Guid SchoolId,
+        IReadOnlyList<Guid> UserIds,
+        string Type,
+        string Title,
+        string? Body,
+        Guid? EntityId,
+        string? EntityType);
+
+    private sealed class RecordingNotificationService : INotificationService
+    {
+        public List<SendBatchCall> Calls { get; } = new();
+
+        public Task SendAsync(
+            Guid schoolId, Guid userId, string type, string title, string? body,
+            Guid? entityId, string? entityType, CancellationToken cancellationToken = default)
+        {
+            Calls.Add(new SendBatchCall(schoolId, new[] { userId }, type, title, body, entityId, entityType));
+            return Task.CompletedTask;
+        }
+
+        public Task SendBatchAsync(
+            Guid schoolId, IReadOnlyList<Guid> userIds, string type, string title, string? body,
+            Guid? entityId, string? entityType, CancellationToken cancellationToken = default)
+        {
+            Calls.Add(new SendBatchCall(schoolId, userIds.ToList(), type, title, body, entityId, entityType));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingNotificationService : INotificationService
+    {
+        public Task SendAsync(
+            Guid schoolId, Guid userId, string type, string title, string? body,
+            Guid? entityId, string? entityType, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("simulated DB outage");
+
+        public Task SendBatchAsync(
+            Guid schoolId, IReadOnlyList<Guid> userIds, string type, string title, string? body,
+            Guid? entityId, string? entityType, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("simulated DB outage");
+    }
+}

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentMagicByteTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentMagicByteTests.cs
@@ -276,6 +276,7 @@ public class AttachmentMagicByteTests
             {
                 if (serviceType == typeof(IStorageService)) return _storage;
                 if (serviceType == typeof(IAttachmentScanner)) return _scanner;
+                if (serviceType == typeof(IAttachmentBlockedNotifier)) return NoOpAttachmentBlockedNotifier.Instance;
                 if (serviceType == typeof(AppDbContext))
                 {
                     _ctx ??= new AppDbContext(_options);

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanFlowTests.cs
@@ -5,6 +5,7 @@ using EduConnect.Api.Infrastructure.Database.Entities;
 using EduConnect.Api.Infrastructure.Services;
 using EduConnect.Api.Infrastructure.Services.Scanning;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -38,7 +39,8 @@ public class AttachmentScanFlowTests
         await using var readContext = new AppDbContext(options, teacher);
         var handler = new GetAttachmentsForEntityQueryHandler(
             readContext, teacher, storage.Object,
-            Options.Create(new StorageOptions()));
+            Options.Create(new StorageOptions()),
+            new HttpContextAccessor());
 
         var result = await handler.Handle(
             new GetAttachmentsForEntityQuery(homeworkId, "homework"),
@@ -111,7 +113,8 @@ public class AttachmentScanFlowTests
         await using var readContext = new AppDbContext(options, parent);
         var handler = new GetAttachmentsForEntityQueryHandler(
             readContext, parent, storage.Object,
-            Options.Create(new StorageOptions()));
+            Options.Create(new StorageOptions()),
+            new HttpContextAccessor());
 
         var result = await handler.Handle(
             new GetAttachmentsForEntityQuery(homeworkId, "homework"),

--- a/apps/api/tests/EduConnect.Api.Tests/AttachmentScanRetryTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/AttachmentScanRetryTests.cs
@@ -211,6 +211,7 @@ public class AttachmentScanRetryTests
             {
                 if (serviceType == typeof(IStorageService)) return _storage;
                 if (serviceType == typeof(IAttachmentScanner)) return _scanner;
+                if (serviceType == typeof(IAttachmentBlockedNotifier)) return NoOpAttachmentBlockedNotifier.Instance;
                 if (serviceType == typeof(AppDbContext))
                 {
                     _ctx ??= new AppDbContext(_options);

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkAttachmentFlowTests.cs
@@ -7,6 +7,7 @@ using EduConnect.Api.Infrastructure.Database;
 using EduConnect.Api.Infrastructure.Database.Entities;
 using EduConnect.Api.Infrastructure.Services;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -176,7 +177,8 @@ public class HomeworkAttachmentFlowTests
             context,
             currentUser,
             storageService.Object,
-            Options.Create(new StorageOptions()));
+            Options.Create(new StorageOptions()),
+            new HttpContextAccessor());
 
         var act = () => handler.Handle(
             new GetAttachmentsForEntityQuery(homeworkId, "homework"),
@@ -272,7 +274,8 @@ public class HomeworkAttachmentFlowTests
             context,
             currentUser,
             storageService.Object,
-            Options.Create(new StorageOptions()));
+            Options.Create(new StorageOptions()),
+            new HttpContextAccessor());
 
         var result = await handler.Handle(
             new GetAttachmentsForEntityQuery(homeworkId, "homework"),

--- a/apps/api/tests/EduConnect.Api.Tests/HomeworkSubmissionAttachmentAclTests.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/HomeworkSubmissionAttachmentAclTests.cs
@@ -5,6 +5,7 @@ using EduConnect.Api.Infrastructure.Database;
 using EduConnect.Api.Infrastructure.Database.Entities;
 using EduConnect.Api.Infrastructure.Services;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -131,7 +132,8 @@ public class HomeworkSubmissionAttachmentAclTests
             context,
             currentUser,
             storage.Object,
-            Options.Create(new StorageOptions()));
+            Options.Create(new StorageOptions()),
+            new HttpContextAccessor());
 
         return await handler.Handle(
             new GetAttachmentsForEntityQuery(submissionId, "homework_submission"),

--- a/apps/api/tests/EduConnect.Api.Tests/NoOpAttachmentBlockedNotifier.cs
+++ b/apps/api/tests/EduConnect.Api.Tests/NoOpAttachmentBlockedNotifier.cs
@@ -1,0 +1,20 @@
+using EduConnect.Api.Infrastructure.Database.Entities;
+using EduConnect.Api.Infrastructure.Services.Scanning;
+
+namespace EduConnect.Api.Tests;
+
+/// <summary>
+/// Test stub: ignores every notification call. Used by worker tests that
+/// don't care about the notifier side-channel and just want a registered
+/// instance so DI doesn't throw.
+/// </summary>
+internal sealed class NoOpAttachmentBlockedNotifier : IAttachmentBlockedNotifier
+{
+    public static readonly NoOpAttachmentBlockedNotifier Instance = new();
+
+    public Task NotifyAsync(
+        AttachmentBlockedKind kind,
+        AttachmentEntity attachment,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
Three changes that close the operator-feedback gap and tighten the upload surface.

6.1 Admin notifications on Infected / ScanFailed. New
    IAttachmentBlockedNotifier (impl in AttachmentBlockedNotifier)
    resolves the active admins of the attachment's school and
    dispatches both an in-app notification (via the existing
    INotificationService → push fan-out) and a best-effort email
    (via IEmailService). The worker calls the notifier from every
    code path that writes Status = Infected or ScanFailed, after
    SaveChangesAsync — failures inside the notifier are absorbed and
    logged so they never undo the primary status write.

    Migration `ExpandNotificationTypesForAttachments` adds
    `attachment_infected` and `attachment_scan_failed` to
    chk_notification_type, and `attachment` to
    chk_notification_entity_type. NotificationConfiguration kept in
    sync.

6.2 Endpoint rate limit on presigned-URL minting. New named policy
    `attachments-upload-url` (10 req/min/user via fixed window)
    applied to /api/attachments/request-upload-url-v2. Sits on top
    of the existing global per-user limit so the upload-URL ceiling
    is the more restrictive of the two. Hourly cap deliberately
    deferred — the per-minute limit already neutralises the
    documented attack (10×60 = 600/hour worst case).

6.3 Audit-log redirect endpoint. New
    GET /api/attachments/{id}/download endpoint loads the row,
    re-runs the existing entity-level access check by dispatching
    GetAttachmentsForEntityQuery, logs at Information with
    {AttachmentId, EntityType, EntityId, UserId, SchoolId}, mints
    a fresh presigned URL, and returns 302. GetAttachmentsForEntity
    now emits this audit URL (absolute, scheme + host pulled from
    IHttpContextAccessor) for `homework_submission` and `notice`
    rows; `homework` rows continue to receive direct presigned URLs
    since the surface is teacher-facing and per-download auditing
    isn't worth the extra hop.

Tests:
- AttachmentBlockedNotifierTests — 5 cases: in-app dispatch to the right admin set (active + same tenant only), correct type per blocked kind, email per admin with an address, notifier failure swallowed, no-admins tenant is a noop.
- Existing scope-factory test stubs updated to provide a NoOpAttachmentBlockedNotifier so the worker's new GetRequiredService call resolves under test.

Suite: 140 passed, 2 pre-existing AdminOnboarding failures unchanged. FE tsc clean.